### PR TITLE
Fix step calculation on multitarget render query

### DIFF
--- a/render/data/multi_target.go
+++ b/render/data/multi_target.go
@@ -89,6 +89,7 @@ func (m *MultiTarget) Fetch(ctx context.Context, cfg *config.Config, chContext s
 			errors = append(errors, err)
 			lock.Unlock()
 			logger.Error("data tables is not specified", zap.Error(err))
+			query.cStep.doneTarget()
 			return EmptyResponse(), err
 		}
 		wg.Add(1)

--- a/render/data/query.go
+++ b/render/data/query.go
@@ -120,6 +120,7 @@ func (q *query) getDataPoints(ctx context.Context, cond *conditions) error {
 
 	cond.prepareMetricsLists()
 	if len(cond.metricsRequested) == 0 {
+		q.cStep.doneTarget()
 		return nil
 	}
 
@@ -306,8 +307,9 @@ func (c *conditions) setStep(cStep *commonStep) {
 		step = cStep.calculateUnsafe(step, int64(s))
 	}
 	cStep.calculate(step)
-	step = dry.Max(cStep.getResult(), dry.Ceil(c.Until-c.From, c.MaxDataPoints))
-	c.step = dry.CeilToMultiplier(step, cStep.getResult())
+	rStep := cStep.getResult()
+	step = dry.Max(rStep, dry.Ceil(c.Until-c.From, c.MaxDataPoints))
+	c.step = dry.CeilToMultiplier(step, rStep)
 	return
 }
 


### PR DESCRIPTION
In some cases doneTraget() not called. This produce timeout in getResult()