### PR TITLE
add health status endpoint for monitoring

### DIFF
--- a/graphite-clickhouse.go
+++ b/graphite-clickhouse.go
@@ -198,6 +198,10 @@ func main() {
 		}
 		w.Write(b)
 	})
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, "Graphite-clickhouse is alive.\n")
+	})
 
 	mux.Handle("/", app.Handler(prometheus.NewHandler(cfg)))
 

--- a/graphite-clickhouse.go
+++ b/graphite-clickhouse.go
@@ -198,7 +198,7 @@ func main() {
 		}
 		w.Write(b)
 	})
-	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/alive", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintf(w, "Graphite-clickhouse is alive.\n")
 	})


### PR DESCRIPTION
Allow other monitoring software(like zabbix and so on) to check graphite-clickhouse health via standalone health check endpoint.
Similiar to https://prometheus.io/docs/prometheus/latest/management_api/#health-check