### PR TITLE
Fix missing results on day start/end (depend on timezone)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,10 +54,38 @@ jobs:
       env:
         CGO_ENABLED: 1
 
+    - name: Test (with GMT-5)
+      run: |
+        go clean -testcache
+        TZ=Etc/GMT-5 make test
+      env:
+        CGO_ENABLED: 1
+
+    - name: Test (with GMT+5)
+      run: |
+        go clean -testcache
+        TZ=Etc/GMT+5 make test
+      env:
+        CGO_ENABLED: 1
+
     - name: Integration tests
       run: |
         make e2e-test
         ./e2e-test -config tests
+
+    # TODO (msaf1980): find a way to set TZ in carbon-clickhouse docker (or run locally)
+    # run with clickhouse.date-format = "both"
+    # - name: Integration tests (with Etc/GMT-5)
+    #   run: |
+    #     make e2e-test
+    #     sudo timedatectl set-timezone Etc/GMT-5
+    #     ./e2e-test -config issues/daytime
+
+    # - name: Integration tests (with Etc/GMT+5)
+    #   run: |
+    #     make e2e-test
+    #     sudo timedatectl set-timezone Etc/GMT+5
+    #     ./e2e-test -config issues/daytime
 
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1

--- a/autocomplete/autocomplete.go
+++ b/autocomplete/autocomplete.go
@@ -13,6 +13,7 @@ import (
 	"github.com/lomik/graphite-clickhouse/config"
 	"github.com/lomik/graphite-clickhouse/finder"
 	"github.com/lomik/graphite-clickhouse/helper/clickhouse"
+	"github.com/lomik/graphite-clickhouse/helper/date"
 	"github.com/lomik/graphite-clickhouse/helper/utils"
 	"github.com/lomik/graphite-clickhouse/metrics"
 	"github.com/lomik/graphite-clickhouse/pkg/scope"
@@ -41,6 +42,12 @@ func NewValues(config *config.Config) *Handler {
 	}
 
 	return h
+}
+
+func dateString(autocompleteDays int, tm time.Time) (string, string) {
+	fromDate := date.FromTimeToDaysFormat(tm.AddDate(0, 0, -autocompleteDays))
+	untilDate := date.UntilTimeToDaysFormat(tm)
+	return fromDate, untilDate
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -172,9 +179,8 @@ func (h *Handler) ServeTags(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	now := time.Now()
-	fromDate := now.AddDate(0, 0, -h.config.ClickHouse.TaggedAutocompleDays).Format("2006-01-02")
-	untilDate := now.Format("2006-01-02")
+	// TODO (msaf1980) fix for disable daily
+	fromDate, untilDate := dateString(h.config.ClickHouse.TaggedAutocompleDays, start)
 
 	var key string
 
@@ -358,8 +364,8 @@ func (h *Handler) ServeValues(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	fromDate := start.AddDate(0, 0, -h.config.ClickHouse.TaggedAutocompleDays).Format("2006-01-02")
-	untilDate := start.Format("2006-01-02")
+	// TODO (msaf1980) fix for disable daily
+	fromDate, untilDate := dateString(h.config.ClickHouse.TaggedAutocompleDays, start)
 
 	var key string
 

--- a/autocomplete/autocomplete_test.go
+++ b/autocomplete/autocomplete_test.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/lomik/graphite-clickhouse/config"
 	"github.com/lomik/graphite-clickhouse/helper/tests/clickhouse"
+	chtest "github.com/lomik/graphite-clickhouse/helper/tests/clickhouse"
 	"github.com/lomik/graphite-clickhouse/metrics"
-
 	"github.com/stretchr/testify/assert"
 )
 
@@ -52,7 +52,7 @@ func testResponce(t *testing.T, step int, h *Handler, tt *testStruct, wantCached
 
 func TestHandler_ServeValues(t *testing.T) {
 	metrics.DisableMetrics()
-	srv := clickhouse.NewTestServer()
+	srv := chtest.NewTestServer()
 	defer srv.Close()
 
 	cfg, _ := config.DefaultConfig()
@@ -60,11 +60,10 @@ func TestHandler_ServeValues(t *testing.T) {
 
 	h := NewTags(cfg)
 
-	from := "1636432127"
-	until := "1636442929"
-
-	fromDate := time.Now().AddDate(0, 0, -h.config.ClickHouse.TaggedAutocompleDays).Format("2006-01-02")
-	untilDate := time.Now().Format("2006-01-02")
+	now := time.Now()
+	until := strconv.FormatInt(now.Unix(), 10)
+	from := strconv.FormatInt(now.Add(-time.Minute).Unix(), 10)
+	fromDate, untilDate := dateString(h.config.ClickHouse.TaggedAutocompleDays, now)
 
 	srv.AddResponce(
 		"SELECT substr(arrayJoin(Tags), 6) AS value FROM graphite_tagged  WHERE (((Tag1='environment=production') AND (arrayExists((x) -> x='project=web', Tags))) AND (arrayJoin(Tags) LIKE 'host=%')) AND "+
@@ -98,6 +97,7 @@ func TestHandler_ServeValues(t *testing.T) {
 }
 
 func TestTagsAutocomplete_ServeValuesCached(t *testing.T) {
+	metrics.DisableMetrics()
 	srv := clickhouse.NewTestServer()
 	defer srv.Close()
 
@@ -118,11 +118,10 @@ func TestTagsAutocomplete_ServeValuesCached(t *testing.T) {
 
 	h := NewTags(cfg)
 
-	from := "1636432127"
-	until := "1636442929"
-
-	fromDate := time.Now().AddDate(0, 0, -h.config.ClickHouse.TaggedAutocompleDays).Format("2006-01-02")
-	untilDate := time.Now().Format("2006-01-02")
+	now := time.Now()
+	until := strconv.FormatInt(now.Unix(), 10)
+	from := strconv.FormatInt(now.Add(-time.Minute).Unix(), 10)
+	fromDate, untilDate := dateString(h.config.ClickHouse.TaggedAutocompleDays, now)
 
 	srv.AddResponce(
 		"SELECT substr(arrayJoin(Tags), 6) AS value FROM graphite_tagged  WHERE (((Tag1='environment=production') AND (arrayExists((x) -> x='project=web', Tags))) AND (arrayJoin(Tags) LIKE 'host=%')) AND "+

--- a/cmd/e2e-test/graphite-clickhouse.go
+++ b/cmd/e2e-test/graphite-clickhouse.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -13,6 +14,7 @@ import (
 	"text/template"
 
 	"github.com/lomik/graphite-clickhouse/helper/client"
+	"github.com/msaf1980/go-stringutils"
 )
 
 type GraphiteClickhouse struct {
@@ -142,4 +144,9 @@ func (c *GraphiteClickhouse) URL() string {
 
 func (c *GraphiteClickhouse) Cmd() string {
 	return strings.Join(c.cmd.Args, " ")
+}
+
+func (c *GraphiteClickhouse) Grep(s string) {
+	out, _ := exec.Command("grep", "-F", s, c.storeDir+"/graphite-clickhouse.log").Output()
+	fmt.Fprintf(os.Stderr, "GREP %s", stringutils.UnsafeString(out))
 }

--- a/doc/config.md
+++ b/doc/config.md
@@ -230,6 +230,8 @@ Send internal metrics to graphite relay
  url = "http://localhost:8123?cancel_http_readonly_queries_on_client_close=1"
  # default total timeout to fetch data, can be overwritten with query-params
  data-timeout = "1m0s"
+ # Date format (default, utc, both)
+ date-format = ""
  # see doc/index-table.md
  index-table = "graphite_index"
  index-use-daily = true

--- a/finder/date_reverse_test.go
+++ b/finder/date_reverse_test.go
@@ -1,0 +1,49 @@
+package finder
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lomik/graphite-clickhouse/helper/clickhouse"
+	"github.com/lomik/graphite-clickhouse/helper/date"
+)
+
+func TestDateFinderV3_whereFilter(t *testing.T) {
+	tests := []struct {
+		name     string
+		query    string
+		from     int64
+		until    int64
+		want     string
+		wantDate string
+	}{
+		{
+			name:     "midnight at utc (direct)",
+			query:    "test.metric*",
+			from:     1668124800, // 2022-11-11 00:00:00 UTC
+			until:    1668124810, // 2022-11-11 00:00:10 UTC
+			want:     "(Level=2) AND (Path LIKE 'metric%' AND match(Path, '^metric([^.]*?)[.]test[.]?$'))",
+			wantDate: "Date >='" + date.FromTimestampToDaysFormat(1668124800) + "' AND Date <= '" + date.UntilTimestampToDaysFormat(1668124810) + "'",
+		},
+		{
+			name:     "midnight at utc (reverse)",
+			query:    "*test.metric",
+			from:     1668124800, // 2022-11-11 00:00:00 UTC
+			until:    1668124810, // 2022-11-11 00:00:10 UTC
+			want:     "(Level=2) AND (Path LIKE 'metric.%' AND match(Path, '^metric[.]([^.]*?)test[.]?$'))",
+			wantDate: "Date >='" + date.FromTimestampToDaysFormat(1668124800) + "' AND Date <= '" + date.UntilTimestampToDaysFormat(1668124810) + "'",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name+" "+time.Unix(tt.from, 0).Format(time.RFC3339), func(t *testing.T) {
+			f := NewDateFinderV3("http://localhost:8123/", "graphite_index", clickhouse.Options{}).(*DateFinderV3)
+			got, gotDate := f.whereFilter(tt.query, tt.from, tt.until)
+			if got.String() != tt.want {
+				t.Errorf("DateFinderV3.whereFilter()[0] = %v, want %v", got, tt.want)
+			}
+			if gotDate.String() != tt.wantDate {
+				t.Errorf("DateFinderV3.whereFilter()[1] = %v, want %v", gotDate, tt.wantDate)
+			}
+		})
+	}
+}

--- a/finder/index_test.go
+++ b/finder/index_test.go
@@ -3,8 +3,11 @@ package finder
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/lomik/graphite-clickhouse/config"
+	"github.com/lomik/graphite-clickhouse/helper/clickhouse"
+	"github.com/lomik/graphite-clickhouse/helper/date"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -132,5 +135,64 @@ func Benchmark_useReverseDepthRegex(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		_ = idx.checkReverses("a.b.c*.d.max")
+	}
+}
+
+func TestIndexFinder_whereFilter(t *testing.T) {
+	tests := []struct {
+		name          string
+		query         string
+		from          int64
+		until         int64
+		dailyEnabled  bool
+		indexReverse  string
+		indexReverses config.IndexReverses
+		want          string
+	}{
+		{
+			name:         "nodaily (direct)",
+			query:        "test.metric*",
+			from:         1668106860,
+			until:        1668106870,
+			dailyEnabled: false,
+			want:         "((Level=20002) AND (Path LIKE 'test.metric%')) AND (Date='1970-02-12')",
+		},
+		{
+			name:         "nodaily (reverse)",
+			query:        "*test.metric",
+			from:         1668106860,
+			until:        1668106870,
+			dailyEnabled: false,
+			want:         "((Level=30002) AND (Path LIKE 'metric.%' AND match(Path, '^metric[.]([^.]*?)test[.]?$'))) AND (Date='1970-02-12')",
+		},
+		{
+			name:         "midnight at utc (direct)",
+			query:        "test.metric*",
+			from:         1668124800, // 2022-11-11 00:00:00 UTC
+			until:        1668124810, // 2022-11-11 00:00:10 UTC
+			dailyEnabled: true,
+			want: "((Level=2) AND (Path LIKE 'test.metric%')) AND (Date >='" +
+				date.FromTimestampToDaysFormat(1668124800) + "' AND Date <= '" + date.UntilTimestampToDaysFormat(1668124810) + "')",
+		},
+		{
+			name:         "midnight at utc (reverse)",
+			query:        "*test.metric",
+			from:         1668124800, // 2022-11-11 00:00:00 UTC
+			until:        1668124810, // 2022-11-11 00:00:10 UTC
+			dailyEnabled: true,
+			want: "((Level=10002) AND (Path LIKE 'metric.%' AND match(Path, '^metric[.]([^.]*?)test[.]?$'))) AND (Date >='" +
+				date.FromTimestampToDaysFormat(1668124800) + "' AND Date <= '" + date.UntilTimestampToDaysFormat(1668124810) + "')",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name+" "+time.Unix(tt.from, 0).Format(time.RFC3339), func(t *testing.T) {
+			if tt.indexReverse == "" {
+				tt.indexReverse = "auto"
+			}
+			idx := NewIndex("http://localhost:8123/", "graphite_index", tt.dailyEnabled, tt.indexReverse, tt.indexReverses, clickhouse.Options{}, false).(*IndexFinder)
+			if got := idx.whereFilter(tt.query, tt.from, tt.until); got.String() != tt.want {
+				t.Errorf("IndexFinder.whereFilter() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/helper/date/date.go
+++ b/helper/date/date.go
@@ -1,0 +1,103 @@
+package date
+
+import "time"
+
+var FromTimestampToDaysFormat func(int64) string
+var FromTimeToDaysFormat func(time.Time) string
+var UntilTimestampToDaysFormat func(int64) string
+var UntilTimeToDaysFormat func(time.Time) string
+
+// SetDefault() is for broken SlowTimestampToDays in carbon-clickhouse
+func SetDefault() {
+	FromTimestampToDaysFormat = DefaultTimestampToDaysFormat
+	FromTimeToDaysFormat = DefaultTimeToDaysFormat
+	UntilTimestampToDaysFormat = DefaultTimestampToDaysFormat
+	UntilTimeToDaysFormat = DefaultTimeToDaysFormat
+}
+
+// SetUTC() is for UTCTimestampToDays in carbon-clickhouse (see https://github.com/go-graphite/carbon-clickhouse/pull/114)
+func SetUTC() {
+	FromTimestampToDaysFormat = UTCTimestampToDaysFormat
+	FromTimeToDaysFormat = UTCTimeToDaysFormat
+	UntilTimestampToDaysFormat = UTCTimestampToDaysFormat
+	UntilTimeToDaysFormat = UTCTimeToDaysFormat
+}
+
+// SetBoth() is for mixed  SlowTimestampToDays/UTCTimestampToDays (before rebuild tables complete)
+func SetBoth() {
+	FromTimestampToDaysFormat = MinTimestampToDaysFormat
+	FromTimeToDaysFormat = MinTimeToDaysFormat
+	UntilTimestampToDaysFormat = MaxTimestampToDaysFormat
+	UntilTimeToDaysFormat = MaxTimeToDaysFormat
+}
+
+func init() {
+	SetDefault()
+}
+
+// from carbon-clickhouse, port of SlowTimestampToDays, broken symmetic, not always UTC
+func DefaultTimestampToDaysFormat(ts int64) string {
+	t := time.Unix(ts, 0)
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC).Format("2006-01-02")
+}
+
+// from carbon-clickhouse, port of SlowTimestampToDays, broken symmetic, not always UTC
+func DefaultTimeToDaysFormat(t time.Time) string {
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC).Format("2006-01-02")
+}
+
+func UTCTimestampToDaysFormat(timestamp int64) string {
+	return time.Unix(timestamp, 0).UTC().Format("2006-01-02")
+}
+
+func UTCTimeToDaysFormat(t time.Time) string {
+	return t.UTC().Format("2006-01-02")
+}
+
+func defaultDate(t time.Time) time.Time {
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
+}
+
+func minLocalAndUTC(t time.Time) time.Time {
+	tu := defaultDate(t.UTC())
+	td := defaultDate(t)
+	if tu.Unix() < td.Unix() {
+		return tu
+	} else {
+		return td
+	}
+}
+
+// MinTimestampToDaysFormat return formatted minimum (local, UTC) date
+func MinTimestampToDaysFormat(ts int64) string {
+	t := minLocalAndUTC(time.Unix(ts, 0))
+	return t.Format("2006-01-02")
+}
+
+// MinTimeToDaysFormat return formatted minimum (local, UTC) date
+func MinTimeToDaysFormat(t time.Time) string {
+	t = minLocalAndUTC(t)
+	return t.Format("2006-01-02")
+}
+
+func maxLocalAndUTC(t time.Time) time.Time {
+	tu := defaultDate(t.UTC())
+	td := defaultDate(t)
+	if tu.Unix() > td.Unix() {
+		return tu
+	} else {
+		return td
+	}
+}
+
+// MaxTimestampToDaysFormat return formatted maximum (local, UTC) date
+func MaxTimestampToDaysFormat(ts int64) string {
+	t := maxLocalAndUTC(time.Unix(ts, 0))
+	return t.Format("2006-01-02")
+}
+
+// MaxTimeToDaysFormat return formatted maximum (local, UTC) date
+func MaxTimeToDaysFormat(t time.Time) string {
+	t = maxLocalAndUTC(t)
+	return t.Format("2006-01-02")
+}

--- a/helper/date/date_test.go
+++ b/helper/date/date_test.go
@@ -1,0 +1,254 @@
+package date
+
+import (
+	"os"
+	"strconv"
+	"testing"
+	"time"
+)
+
+var verbose bool
+
+func isVerbose() bool {
+	for _, arg := range os.Args {
+		if arg == "-test.v=true" {
+			return true
+		}
+	}
+	return false
+}
+
+func init() {
+	verbose = isVerbose()
+}
+
+// TimestampDaysFormat is broken symmetic with carbon-clickhouse of SlowTimestampToDays, not always UTC
+// $ TZ=Etc/GMT-5 go test -v -timeout 30s -run ^TestTimestampDaysFormat$ github.com/lomik/graphite-clickhouse/helper/date
+// === RUN   TestTimestampDaysFormat
+// === RUN   TestTimestampDaysFormat/1668106870_2022-11-11T00:01:10+05:00_2022-11-10T19:01:10Z_[0]
+//
+//	date_test.go:62: Warning (TimestampDaysFormat broken) TimestampDaysFormat(1668106870) = 2022-11-11, want UTC 2022-11-10
+//
+// --- FAIL: TestTimestampDaysFormat (0.00s)
+//
+//	--- FAIL: TestTimestampDaysFormat/1668106870_2022-11-11T00:01:10+05:00_2022-11-10T19:01:10Z_[0] (0.00s)
+//
+// FAIL
+// FAIL	github.com/lomik/graphite-clickhouse/helper/date	0.001s
+//
+// $ TZ=Etc/GMT+5 go test -v -timeout 30s -run ^TestTimestampDaysFormat$ github.com/lomik/graphite-clickhouse/helper/date
+// === RUN   TestTimestampDaysFormat
+// === RUN   TestTimestampDaysFormat/1668124800_2022-11-10T19:00:00-05:00_2022-11-11T00:00:00Z_[1]
+//
+//	date_test.go:62: Warning (TimestampDaysFormat broken) TimestampDaysFormat(1668124800) = 2022-11-10, want UTC 2022-11-11
+//
+// === RUN   TestTimestampDaysFormat/1668142799_2022-11-10T23:59:59-05:00_2022-11-11T04:59:59Z_[2]
+//
+//	date_test.go:62: Warning (TimestampDaysFormat broken) TimestampDaysFormat(1668142799) = 2022-11-10, want UTC 2022-11-11
+//
+// === RUN   TestTimestampDaysFormat/1650776160_2022-04-23T23:56:00-05:00_2022-04-24T04:56:00Z_[3]
+//
+//	date_test.go:62: Warning (TimestampDaysFormat broken) TimestampDaysFormat(1650776160) = 2022-04-23, want UTC 2022-04-24
+//
+// --- FAIL: TestTimestampDaysFormat (0.00s)
+func TestDefaultTimestampToDaysFormat(t *testing.T) {
+	tests := []struct {
+		ts   int64
+		want string
+	}{
+		{
+			ts: 1668106870, // 2022-11-11 00:01:10 +05:00 ; 2022-11-10 19:01:10 UTC
+			// select toDate(1650776160,'UTC')
+			//     2022-11-10
+			want: time.Unix(1668106870, 0).Format("2006-01-02"),
+		},
+		{
+			ts:   1668124800, // 2022-11-11 00:00:00 UTC
+			want: time.Unix(1668124800, 0).Format("2006-01-02"),
+		},
+		{
+			ts:   1668142799, // 2022-11-10 23:59:59 -05:00; 2022-11-11 04:59:59 UTC
+			want: time.Unix(1668142799, 0).Format("2006-01-02"),
+		},
+		{
+			ts: 1650776160, // graphite-clickhouse issue #184, graphite-clickhouse in UTC, clickhouse in PDT(UTC-7)
+			// 2022-04-24 4:56:00
+			// select toDate(1650776160,'UTC')
+			//                        2022-04-24
+			// select toDate(1650776160,'Etc/GMT+7')
+			//                        2022-04-23
+			want: time.Unix(1650776160, 0).Format("2006-01-02"),
+		},
+	}
+	for i, tt := range tests {
+		t.Run(strconv.FormatInt(tt.ts, 10)+" "+time.Unix(tt.ts, 0).Format(time.RFC3339)+" "+time.Unix(tt.ts, 0).UTC().Format(time.RFC3339)+" ["+strconv.Itoa(i)+"]", func(t *testing.T) {
+			if got := DefaultTimestampToDaysFormat(tt.ts); got != tt.want {
+				t.Errorf("DefaultTimestampDaysFormat(%d) = %s, want %s", tt.ts, got, tt.want)
+			} else if gotUTC := UTCTimestampToDaysFormat(tt.ts); got != gotUTC {
+				// Run to see a warning
+				// go test -v -timeout 30s -run ^TestTimestampDaysFormat$ github.com/lomik/graphite-clickhouse/helper/date
+				if verbose {
+					t.Errorf("Warning (DefaultTimestampDaysFormat broken) DefaultTimestampDaysFormat(%d) = %s, want UTC %s", tt.ts, got, gotUTC)
+				} else {
+					t.Logf("Warning (DefaultTimestampDaysFormat broken) DefaultTimestampDaysFormat(%d) = %s, want UTC %s", tt.ts, got, gotUTC)
+				}
+			}
+		})
+	}
+}
+
+func TestDefaultTimeToDaysFormat(t *testing.T) {
+	tests := []struct {
+		ts   int64
+		want string
+	}{
+		{
+			ts: 1668106870, // 2022-11-11 00:01:10 +05:00 ; 2022-11-10 19:01:10 UTC
+			// select toDate(1650776160,'UTC')
+			//     2022-11-10
+			want: time.Unix(1668106870, 0).Format("2006-01-02"),
+		},
+		{
+			ts:   1668124800, // 2022-11-11 00:00:00 UTC
+			want: time.Unix(1668124800, 0).Format("2006-01-02"),
+		},
+		{
+			ts:   1668142799, // 2022-11-10 23:59:59 -05:00; 2022-11-11 04:59:59 UTC
+			want: time.Unix(1668142799, 0).Format("2006-01-02"),
+		},
+		{
+			ts: 1650776160, // graphite-clickhouse issue #184, graphite-clickhouse in UTC, clickhouse in PDT(UTC-7)
+			// 2022-04-24 4:56:00
+			// select toDate(1650776160,'UTC')
+			//                        2022-04-24
+			// select toDate(1650776160,'Etc/GMT+7')
+			//                        2022-04-23
+			want: time.Unix(1650776160, 0).Format("2006-01-02"),
+		},
+	}
+	for i, tt := range tests {
+		t.Run(strconv.FormatInt(tt.ts, 10)+" "+time.Unix(tt.ts, 0).UTC().Format(time.RFC3339)+" ["+strconv.Itoa(i)+"]", func(t *testing.T) {
+			if got := DefaultTimeToDaysFormat(time.Unix(tt.ts, 0)); got != tt.want {
+				t.Errorf("DefaultTimeDaysFormat() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUTCTimestampToDaysFormat(t *testing.T) {
+	tests := []struct {
+		ts   int64
+		want string
+	}{
+		{
+			ts: 1668106870, // 2022-11-11 00:01:10 +05:00 ; 2022-11-10 19:01:10 UTC
+			// select toDate(1650776160,'UTC')
+			//     2022-11-10
+			want: "2022-11-10",
+		},
+		{
+			ts:   1668124800, // 2022-11-11 00:00:00 UTC
+			want: "2022-11-11",
+		},
+		{
+			ts:   1668142799, // 2022-11-10 23:59:59 -05:00; 2022-11-11 04:59:59 UTC
+			want: "2022-11-11",
+		},
+		{
+			ts: 1650776160, // graphite-clickhouse issue #184, graphite-clickhouse in UTC, clickhouse in PDT(UTC-7)
+			// 2022-04-24 4:56:00
+			// select toDate(1650776160,'UTC')
+			//                        2022-04-24
+			// select toDate(1650776160,'Etc/GMT+7')
+			//                        2022-04-23
+			want: "2022-04-24",
+		},
+	}
+	for i, tt := range tests {
+		t.Run(strconv.FormatInt(tt.ts, 10)+" "+time.Unix(tt.ts, 0).Format(time.RFC3339)+" "+time.Unix(tt.ts, 0).UTC().Format(time.RFC3339)+" ["+strconv.Itoa(i)+"]", func(t *testing.T) {
+			if got := UTCTimestampToDaysFormat(tt.ts); got != tt.want {
+				t.Errorf("UTCTimestampDaysFormat(%d) = %s, want %s", tt.ts, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUTCTimeToDaysFormat(t *testing.T) {
+	tests := []struct {
+		ts   int64
+		want string
+	}{
+		{
+			ts: 1668106870, // 2022-11-11 00:01:10 +05:00 ; 2022-11-10 19:01:10 UTC
+			// select toDate(1650776160,'UTC')
+			//     2022-11-10
+			want: "2022-11-10",
+		},
+		{
+			ts:   1668124800, // 2022-11-11 00:00:00 UTC
+			want: "2022-11-11",
+		},
+		{
+			ts:   1668142799, // 2022-11-10 23:59:59 -05:00; 2022-11-11 04:59:59 UTC
+			want: "2022-11-11",
+		},
+		{
+			ts: 1650776160, // graphite-clickhouse issue #184, graphite-clickhouse in UTC, clickhouse in PDT(UTC-7)
+			// 2022-04-24 4:56:00
+			// select toDate(1650776160,'UTC')
+			//                        2022-04-24
+			// select toDate(1650776160,'Etc/GMT+7')
+			//                        2022-04-23
+			want: "2022-04-24",
+		},
+	}
+	for i, tt := range tests {
+		t.Run(strconv.FormatInt(tt.ts, 10)+" "+time.Unix(tt.ts, 0).UTC().Format(time.RFC3339)+" ["+strconv.Itoa(i)+"]", func(t *testing.T) {
+			if got := UTCTimeToDaysFormat(time.Unix(tt.ts, 0)); got != tt.want {
+				t.Errorf("UTCTimeDaysFormat() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMinMaxTimestampToDaysFormat(t *testing.T) {
+	tests := []struct {
+		ts int64
+	}{
+		{
+			ts: 1668106870, // 2022-11-11 00:01:10 +05:00 ; 2022-11-10 19:01:10 UTC
+			// select toDate(1650776160,'UTC')
+			//     2022-11-10
+		},
+		{
+			ts: 1668124800, // 2022-11-11 00:00:00 UTC
+		},
+		{
+			ts: 1668142799, // 2022-11-10 23:59:59 -05:00; 2022-11-11 04:59:59 UTC
+		},
+		{
+			ts: 1650776160, // graphite-clickhouse issue #184, graphite-clickhouse in UTC, clickhouse in PDT(UTC-7)
+			// 2022-04-24 4:56:00
+			// select toDate(1650776160,'UTC')
+			//                        2022-04-24
+			// select toDate(1650776160,'Etc/GMT+7')
+			//                        2022-04-23
+		},
+	}
+	for i, tt := range tests {
+		t.Run(strconv.FormatInt(tt.ts, 10)+" "+time.Unix(tt.ts, 0).UTC().Format(time.RFC3339)+" ["+strconv.Itoa(i)+"]", func(t *testing.T) {
+			gotMin := MinTimestampToDaysFormat(tt.ts)
+			timeMin, _ := time.Parse("2006-01-02", gotMin)
+			gotMax := MaxTimestampToDaysFormat(tt.ts)
+			timeMax, _ := time.Parse("2006-01-02", gotMax)
+			got := DefaultTimestampToDaysFormat(tt.ts)
+			tm, _ := time.Parse("2006-01-02", got)
+
+			if timeMin.UnixNano() > timeMax.UnixNano() || tm.UnixNano() > timeMax.UnixNano() || tm.UnixNano() < timeMin.UnixNano() {
+				t.Errorf("MinTimeDaysFormat() = %s > MaxTimeDaysFormat() = %s, DefaultTimeDaysFormat() = %s", gotMin, gotMax, got)
+			} else {
+				t.Logf("MinTimeDaysFormat() = %s, MaxTimeDaysFormat() = %s, DefaultTimeDaysFormat() = %s", gotMin, gotMax, got)
+			}
+		})
+	}
+}

--- a/helper/datetime/datetime_test.go
+++ b/helper/datetime/datetime_test.go
@@ -32,6 +32,7 @@ func TestDateParamToEpoch(t *testing.T) {
 		{"midnight-10", "23:59:50 1994-Aug-15"},
 		{"midnight-1s", "23:59:59 1994-Aug-15"},
 		{"midnight-1day", "00:00:00 1994-Aug-15"},
+		{"midnight-1day+1s", "00:00:01 1994-Aug-15"},
 	}
 
 	for _, tt := range tests {

--- a/issues/daytime/carbon-clickhouse.conf.tpl
+++ b/issues/daytime/carbon-clickhouse.conf.tpl
@@ -1,0 +1,45 @@
+[common]
+
+[data]
+path = "/etc/carbon-clickhouse/data"
+chunk-interval = "1s"
+chunk-auto-interval = ""
+
+[upload.graphite_index]
+type = "index"
+table = "graphite_index"
+url = "{{ .CLICKHOUSE_URL }}/"
+timeout = "2m30s"
+cache-ttl = "1h"
+
+[upload.graphite_tags]
+type = "tagged"
+table = "graphite_tags"
+threads = 3
+url = "{{ .CLICKHOUSE_URL }}/"
+timeout = "2m30s"
+cache-ttl = "1h"
+
+[upload.graphite_reverse]
+type = "points-reverse"
+table = "graphite_reverse"
+url = "{{ .CLICKHOUSE_URL }}/"
+timeout = "2m30s"
+zero-timestamp = false
+
+[upload.graphite]
+type = "points"
+table = "graphite"
+url = "{{ .CLICKHOUSE_URL }}/"
+timeout = "2m30s"
+zero-timestamp = false
+
+[tcp]
+listen = ":2003"
+enabled = true
+drop-future = "0s"
+drop-past = "0s"
+
+[logging]
+file = "/etc/carbon-clickhouse/carbon-clickhouse.log"
+level = "debug"

--- a/issues/daytime/graphite-clickhouse-internal-aggr.conf.tpl
+++ b/issues/daytime/graphite-clickhouse-internal-aggr.conf.tpl
@@ -1,0 +1,35 @@
+[common]
+listen = "{{ .GCH_ADDR }}"
+max-cpu = 0
+max-metrics-in-render-answer = 10000
+max-metrics-per-target = 10000
+headers-to-log = [ "X-Ctx-Carbonapi-Uuid" ]
+
+[clickhouse]
+url = "{{ .CLICKHOUSE_URL }}/?max_rows_to_read=500000000&max_result_bytes=1073741824&readonly=2&log_queries=1"
+data-timeout = "30s"
+
+index-table = "graphite_index"
+index-use-daily = true
+index-timeout = "1m"
+internal-aggregation = true
+
+tagged-table = "graphite_tags"
+tagged-autocomplete-days = 1
+
+date-format = "both"
+
+[[data-table]]
+# # clickhouse table name
+table = "graphite"
+# # points in table are stored with reverse path
+reverse = false
+rollup-conf = "auto"
+
+[[logging]]
+logger = ""
+file = "{{ .GCH_DIR }}/graphite-clickhouse.log"
+level = "info"
+encoding = "json"
+encoding-time = "iso8601"
+encoding-duration = "seconds"

--- a/issues/daytime/graphite-clickhouse.conf.tpl
+++ b/issues/daytime/graphite-clickhouse.conf.tpl
@@ -1,0 +1,35 @@
+[common]
+listen = "{{ .GCH_ADDR }}"
+max-cpu = 0
+max-metrics-in-render-answer = 10000
+max-metrics-per-target = 10000
+headers-to-log = [ "X-Ctx-Carbonapi-Uuid" ]
+
+[clickhouse]
+url = "{{ .CLICKHOUSE_URL }}/?max_rows_to_read=500000000&max_result_bytes=1073741824&readonly=2&log_queries=1"
+data-timeout = "30s"
+
+index-table = "graphite_index"
+index-use-daily = true
+index-timeout = "1m"
+internal-aggregation = false
+
+tagged-table = "graphite_tags"
+tagged-autocomplete-days = 1
+
+date-format = "both"
+
+[[data-table]]
+# # clickhouse table name
+table = "graphite"
+# # points in table are stored with reverse path
+reverse = false
+rollup-conf = "auto"
+
+[[logging]]
+logger = ""
+file = "{{ .GCH_DIR }}/graphite-clickhouse.log"
+level = "info"
+encoding = "json"
+encoding-time = "iso8601"
+encoding-duration = "seconds"

--- a/issues/daytime/test.toml
+++ b/issues/daytime/test.toml
@@ -2,23 +2,13 @@
 precision = "10s"
 
 [[test.clickhouse]]
-version = "20.3"
-dir = "tests/clickhouse/rollup"
-
-[[test.clickhouse]]
-version = "20.8"
-dir = "tests/clickhouse/rollup"
-
-[[test.clickhouse]]
-version = "21.3"
-dir = "tests/clickhouse/rollup"
-
-[[test.clickhouse]]
 version = "latest"
 dir = "tests/clickhouse/rollup"
 
 [test.carbon_clickhouse]
-version = "v0.11.1"
+#version = "v0.11.1"
+image = "msaf1980/carbon-clickhouse"
+version = "tz"
 template = "carbon-clickhouse.conf.tpl"
 
 [[test.graphite_clickhouse]]
@@ -396,7 +386,10 @@ from = "midnight+60s"
 until = "midnight+70s"
 targets = [ 
     "*test.midnight",
- ]
+]
+dump_if_empty = [
+    "SELECT Date, Path FROM graphite_index WHERE ((Level=2) AND (Path LIKE 'test.midnight%')) GROUP BY Date, Path"
+]
 
 [[test.render_checks.result]]
 name = "test.midnight"
@@ -454,6 +447,9 @@ query = "name;scope=23h"
 result = [
     "now",
 ]
+dump_if_empty = [
+    "SELECT Date, Tags FROM graphite_tags WHERE ((Tag1='scope=23h') AND (arrayJoin(Tags) LIKE '__name__=%')) GROUP BY Date, Tags ORDER BY Date, Tags"
+]
 
 [[test.render_checks]]
 name = "Day end"
@@ -462,7 +458,10 @@ from = "midnight+1380m"
 until = "midnight+1380m+10s"
 targets = [ 
     "test.23h",
- ]
+]
+dump_if_empty = [
+    "SELECT Date, Path FROM graphite_index WHERE ((Level=2) AND (Path IN ('test.23h','test.23h.'))) GROUP BY Date, Path"
+]
 
 [[test.render_checks.result]]
 name = "test.23h"

--- a/pkg/where/where.go
+++ b/pkg/where/where.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"unsafe"
 
+	"github.com/lomik/graphite-clickhouse/helper/date"
 	"github.com/lomik/graphite-clickhouse/helper/errs"
 )
 
@@ -178,8 +179,8 @@ func InTable(field string, table string) string {
 
 func DateBetween(field string, from int64, until int64) string {
 	return fmt.Sprintf(
-		"%s >= toDate(%d) AND %s <= toDate(%d)",
-		field, from, field, until,
+		"%s >= '%s' AND %s <= '%s'",
+		field, date.FromTimestampToDaysFormat(from), field, date.UntilTimestampToDaysFormat(until),
 	)
 }
 

--- a/render/data/query_test.go
+++ b/render/data/query_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/lomik/graphite-clickhouse/finder"
+	"github.com/lomik/graphite-clickhouse/helper/date"
 	"github.com/lomik/graphite-clickhouse/helper/rollup"
 	"github.com/lomik/graphite-clickhouse/pkg/alias"
 	"github.com/lomik/graphite-clickhouse/pkg/reverse"
@@ -423,19 +424,19 @@ func TestGenerateQuery(t *testing.T) {
 		unaggregated string
 	}{
 		{
-			in: in{1, 13, 1, "avg"},
-			aggregated: ("WITH anyResample(1, 13, 1)(toUInt32(intDiv(Time, 1)*1), Time) AS mask\n" +
+			in: in{1668124800, 1668325322, 1, "avg"},
+			aggregated: ("WITH anyResample(1668124800, 1668325322, 1)(toUInt32(intDiv(Time, 1)*1), Time) AS mask\n" +
 				"SELECT Path,\n arrayFilter(m->m!=0, mask) AS times,\n" +
-				" arrayFilter((v,m)->m!=0, avgResample(1, 13, 1)(Value, Time), mask) AS values\n" +
+				" arrayFilter((v,m)->m!=0, avgResample(1668124800, 1668325322, 1)(Value, Time), mask) AS values\n" +
 				"FROM graphite.table\n" +
-				"PREWHERE Date >= toDate(1) AND Date <= toDate(13)\n" +
-				"WHERE (Path in metrics_list) AND (Time >= 1 AND Time <= 13)\n" +
+				"PREWHERE Date >= '" + date.FromTimestampToDaysFormat(1668124800) + "' AND Date <= '" + date.UntilTimestampToDaysFormat(1668325322) + "'\n" +
+				"WHERE (Path in metrics_list) AND (Time >= 1668124800 AND Time <= 1668325322)\n" +
 				"GROUP BY Path\n" +
 				"FORMAT RowBinary"),
 			unaggregated: ("SELECT Path, groupArray(Time), groupArray(Value), groupArray(Timestamp)\n" +
 				"FROM graphite.table\n" +
-				"PREWHERE Date >= toDate(1) AND Date <= toDate(13)\n" +
-				"WHERE (Path in metrics_list) AND (Time >= 1 AND Time <= 13)\n" +
+				"PREWHERE Date >= '" + date.FromTimestampToDaysFormat(1668124800) + "' AND Date <= '" + date.UntilTimestampToDaysFormat(1668325322) + "'\n" +
+				"WHERE (Path in metrics_list) AND (Time >= 1668124800 AND Time <= 1668325322)\n" +
 				"GROUP BY Path\n" +
 				"FORMAT RowBinary"),
 		},
@@ -445,13 +446,13 @@ func TestGenerateQuery(t *testing.T) {
 				"SELECT Path,\n arrayFilter(m->m!=0, mask) AS times,\n" +
 				" arrayFilter((v,m)->m!=0, minResample(11111, 33333, 11111)(Value, Time), mask) AS values\n" +
 				"FROM graphite.table\n" +
-				"PREWHERE Date >= toDate(11111) AND Date <= toDate(33333)\n" +
+				"PREWHERE Date >= '" + date.FromTimestampToDaysFormat(11111) + "' AND Date <= '" + date.FromTimestampToDaysFormat(33333) + "'\n" +
 				"WHERE (Path in metrics_list) AND (Time >= 11111 AND Time <= 33333)\n" +
 				"GROUP BY Path\n" +
 				"FORMAT RowBinary"),
 			unaggregated: ("SELECT Path, groupArray(Time), groupArray(Value), groupArray(Timestamp)\n" +
 				"FROM graphite.table\n" +
-				"PREWHERE Date >= toDate(11111) AND Date <= toDate(33333)\n" +
+				"PREWHERE Date >= '" + date.FromTimestampToDaysFormat(11111) + "' AND Date <= '" + date.UntilTimestampToDaysFormat(33333) + "'\n" +
 				"WHERE (Path in metrics_list) AND (Time >= 11111 AND Time <= 33333)\n" +
 				"GROUP BY Path\n" +
 				"FORMAT RowBinary"),

--- a/tests/agg_oneblock/test.toml
+++ b/tests/agg_oneblock/test.toml
@@ -53,6 +53,9 @@ until = "rnow+10"
 targets = [ 
     "test.{avg,min,max,sum}"
 ]
+dump_if_empty = [
+    "SELECT Date, Path FROM graphite_index WHERE ((Level=2) AND (Path LIKE 'test.%' AND match(Path, '^test[.](avg|min|max|sum)[.]?$'))) GROUP BY Date, Path"
+]
 
 [[test.render_checks.result]]
 name = "test.avg"


### PR DESCRIPTION
SlowTimestampToDays in carbon-clickhouse broken (Date serialized sometimes in UTC, sometimes in Local, depend on datetime).
This PR provide symmetric broken format Date and also allow to switch to UTC date.
