### PR TITLE
e2e tests: fetch clickhouse logs on connect failure

### DIFF
--- a/cmd/e2e-test/e2etesting.go
+++ b/cmd/e2e-test/e2etesting.go
@@ -464,7 +464,6 @@ func testGraphiteClickhouse(test *TestSchema, clickhouse *Clickhouse, testDir, r
 				zap.String("clickhouse config", clickhouseDir),
 				zap.String("error", "clickhouse is down"),
 			)
-			clickhouse.Logs()
 			testSuccess = false
 		}
 
@@ -510,6 +509,10 @@ func testGraphiteClickhouse(test *TestSchema, clickhouse *Clickhouse, testDir, r
 	}
 
 	test.Proxy.Stop()
+
+	if !clickhouse.Alive() {
+		clickhouse.CopyLog(os.TempDir(), 10)
+	}
 
 	out, err = clickhouse.Stop(true)
 	if err != nil {

--- a/cmd/e2e-test/utils.go
+++ b/cmd/e2e-test/utils.go
@@ -1,0 +1,1 @@
+package main


### PR DESCRIPTION
Tail clickhouse-server log from container on connect failure.