### PR TITLE
Prometheus series fixes

### DIFF
--- a/prometheus/querier_select.go
+++ b/prometheus/querier_select.go
@@ -35,18 +35,18 @@ func (q *Querier) lookup(from, until time.Time, labelsMatcher ...*labels.Matcher
 func (q *Querier) Select(sortSeries bool, hints *storage.SelectHints, labelsMatcher ...*labels.Matcher) storage.SeriesSet {
 	var from, until time.Time
 
-	if from.IsZero() && hints != nil && hints.Start != 0 {
+	// ClickHouse supported range of values by the Date type:  [1970-01-01, 2149-06-06]
+	if from.IsZero() && hints != nil && hints.Start > 0 && hints.Start < 5662310400000 {
 		from = time.Unix(hints.Start/1000, (hints.Start%1000)*1000000)
 	}
-	if until.IsZero() && hints != nil && hints.End != 0 {
+	if until.IsZero() && hints != nil && hints.End > 0 && hints.End < 5662310400000 {
 		until = time.Unix(hints.End/1000, (hints.End%1000)*1000000)
 	}
 
-	if from.IsZero() && q.mint > 0 {
+	if from.IsZero() && q.mint > 0 && q.mint < 5662310400000 {
 		from = time.Unix(q.mint/1000, (q.mint%1000)*1000000)
 	}
-	// ClickHouse supported Datetime range of values: [1970-01-01 00:00:00, 2105-12-31 23:59:59]
-	if until.IsZero() && q.maxt > 0 && q.maxt <= 4291765199000 {
+	if until.IsZero() && q.maxt > 0 && q.maxt < 5662310400000 {
 		until = time.Unix(q.maxt/1000, (q.maxt%1000)*1000000)
 	}
 

--- a/prometheus/querier_select.go
+++ b/prometheus/querier_select.go
@@ -66,7 +66,7 @@ func (q *Querier) Select(sortSeries bool, hints *storage.SelectHints, labelsMatc
 		return emptySeriesSet()
 	}
 
-	if hints == nil {
+	if hints != nil && hints.Func == "series" {
 		// /api/v1/series?match[]=...
 		return newMetricsSet(am.DisplayNames()) //, nil, nil
 	}


### PR DESCRIPTION
```curl -g '127.0.0.1:9092/api/v1/series?' --data-urlencode 'match[]=test_metric'```

/api/v1/series panic fix
```
[2022-11-28T03:14:55.806-0500] ERROR query {"query": "SELECT Path FROM default.graphite_tagged_new  WHERE (Tag1='__name__=test_metric') AND (Date >='-292273086-05-16' AND Date <= '292277025-08-18') GROUP BY Path FORMAT TabSeparatedRaw", "read_bytes": "0", "written_rows": "0", "written_bytes": "0", "total_rows_to_read": "0", "read_rows": "0", "error": "clickhouse response status 400: Code: 53, e.displayText() = DB::Exception: Cannot convert string -292273086-05-16 to type Date: while executing 'FUNCTION greaterOrEquals(Date : 0, '-292273086-05-16' : 1) -> greaterOrEquals(Date, '-292273086-05-16') UInt8 : 3' (version 21.8.12.29.altinitystable (altinity build))\n", "time": 0.897405105}
[2022-11-28T03:14:55.807-0500] ERROR [prometheus] panic while serving request {"client": "127.0.0.1:29925", "url": "/api/v1/series?", "err": "runtime error: invalid memory address or nil pointer dereference", "stack":  ...
```
/api/v1/series excessive query fix
```
[2022-11-28T03:19:04.616-0500] INFO query {"query": "SELECT Path FROM default.graphite_tagged_new  WHERE (Tag1='__name__=test_metric') AND (Date >='2022-11-21' AND Date <= '2022-11-28') GROUP BY Path FORMAT TabSeparatedRaw", "total_rows_to_read": "25", "read_rows": "25", "read_bytes": "1193", "written_rows": "0", "written_bytes": "0", "query_id": "::4bc39315bcd3ec26", "time": 0.022406343}
[2022-11-28T03:19:04.670-0500] INFO query {"query": "SELECT Path, groupArray(Time), groupArray(Value), groupArray(Timestamp) FROM default.graphite_points_r1m PREWHERE Date >= '2022-11-21' AND Date <= '2022-11-28' WHERE (Path in metrics_list) AND (Time >= 1669018800 AND Time <= 1669623599) GROUP BY Path FORMAT RowBinary", "read_rows": "74", "read_bytes": "4685", "written_rows": "0", "written_bytes": "0", "total_rows_to_read": "74", "query_id": "::0a88e7151fea058c", "time": 0.053750981}
```