### PR TITLE
finder: restrict seriesByTag (require minimum non-wildcarded eq arguments)

### DIFF
--- a/autocomplete/autocomplete.go
+++ b/autocomplete/autocomplete.go
@@ -87,7 +87,7 @@ func (h *Handler) requestExpr(r *http.Request) (*where.Where, *where.Where, map[
 		return wr, pw, usedTags, nil
 	}
 
-	terms, err := finder.ParseTaggedConditions(expr, h.config.ClickHouse.TaggedCosts)
+	terms, err := finder.ParseTaggedConditions(expr, h.config)
 	if err != nil {
 		return wr, pw, usedTags, err
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -144,6 +144,7 @@ type ClickHouse struct {
 	FindLimiter          limiter.ServerLimiter `toml:"-" json:"-"`
 	TagsMaxQueries       int                   `toml:"tags-max-queries" json:"tags-max-queries" comment:"Max queries for tags queries"`
 	TagsMaxConcurrent    int                   `toml:"tags-max-concurrent" json:"tags-max-concurrent" comment:"Maximum concurrent queries for tags queries"`
+	TagsMinInQuery       int                   `toml:"tags-min-in-query" json:"tags-min-in-query" comment:"Minimum tags in seriesByTag query"`
 	TagsLimiter          limiter.ServerLimiter `toml:"-" json:"-"`
 	UserLimits           map[string]UserLimits `toml:"user-limits" json:"user-limits" comment:"customized query limiter for some users" commented:"true"`
 	DateFormat           string                `toml:"date-format" json:"date-format" comment:"Date format (default, utc, both)"`

--- a/deploy/doc/config.md
+++ b/deploy/doc/config.md
@@ -126,6 +126,12 @@ CREATE TABLE graphite_tagged (
 ORDER BY (Tag1, Path);
 ```
 
+For restrict costly seriesByTag (may be like `seriesByTag('name=~test.*.*.rabbitmq_overview.connections')` or `seriesByTag('name=test.*.*.rabbitmq_overview.connections')`) use tags-min-in-query parameter.
+
+set for require at minimum 1 eq argument (without wildcards)
+`tags-min-in-query=1`
+
+
 `ReplacingMergeTree(Date)` prevent broken tags autocomplete with default `ReplacingMergeTree(Version)`, when write to the past.
 
 ### ClickHouse aggregation
@@ -160,41 +166,4 @@ When `reverse = true` is set for data-table, there are two possibles cases for [
 Depends on it for having a proper retention and aggregation you must additionally set `rollup-use-reverted = true` for the first case and `rollup-use-reverted = false` for the second.
 
 #### Additional tuning tagged find for seriesByTag and autocomplete
-Only one tag used as filter for index field Tag1, see graphite_tagged table [structure](https://github.com/lomik/carbon-clickhouse#clickhouse-configuration)
-
-So, if the first tag in filter is costly (poor selectivity), like environment (with several possible values), query perfomance will be degraded.
-Tune this with `tagged-costs` options:
-
-```
-tagged-costs = {
-    "environment" = { cost: 100 },
-    "project" = { values-cost = { "HugeProject" = 90 } } # overwrite tag value cost for some value only
-}
-```
-
-Default cost is 0 and positive or negative numbers can be used. So if environment is first tag filter in query, it will used as primary only if no other filters with equal operation. Costs from values-cost also applied to regex match or wilrdcarded equal.
-
-## Carbonlink `[carbonlink]`
-The configuration to get metrics from carbon-cache. See details in [graphite-web](https://graphite.readthedocs.io/en/latest/carbon-daemons.html#carbon-relay-py) documentation.
-
-***TODO***: add the real use-case configuration.
-
-## Logging `[logging]`
-It's possible to set multiple loggers. See `Config` description in [config.go](https://github.com/lomik/zapwriter/blob/master/config.go) for details.
-
-## Metrics `[metrics]`
-
-Send internal metrics to graphite relay
- - `metric-endpoint`   - graphite relay address
- - `statsd-endpoint`   - StatsD aggregator address
- - `metric-interval`   - graphite metrics send interval
- - `metric-prefix`     - graphite metrics prefix 
- - `metric-timeout`    - graphite metrics send timeout
- - `ranges`            - separate stat for render query (and internal clickhouse queries) until-from ranges, for example { "1d" = "24h", "7d" = "168h", "90d" = "2160h" }
- - `request-buckets`   - request historgram buckets widths, by default [200, 500, 1000, 2000, 3000, 5000, 7000, 10000, 15000, 20000, 25000, 30000, 40000, 50000, 60000]
- - `request-labels`    - optional request historgram buckets labels
-
-[//]: # (!!!DO NOT EDIT FOLLOWING LINES!!!)
-
-# Example
-
+Only one tag used as filter for index field Tag1, see graphite_tagged table [structure](https://github.com/lomik/

--- a/doc/config.md
+++ b/doc/config.md
@@ -129,6 +129,12 @@ CREATE TABLE graphite_tagged (
 ORDER BY (Tag1, Path);
 ```
 
+For restrict costly seriesByTag (may be like `seriesByTag('name=~test.*.*.rabbitmq_overview.connections')` or `seriesByTag('name=test.*.*.rabbitmq_overview.connections')`) use tags-min-in-query parameter.
+
+set for require at minimum 1 eq argument (without wildcards)
+`tags-min-in-query=1`
+
+
 `ReplacingMergeTree(Date)` prevent broken tags autocomplete with default `ReplacingMergeTree(Version)`, when write to the past.
 
 ### ClickHouse aggregation
@@ -163,45 +169,7 @@ When `reverse = true` is set for data-table, there are two possibles cases for [
 Depends on it for having a proper retention and aggregation you must additionally set `rollup-use-reverted = true` for the first case and `rollup-use-reverted = false` for the second.
 
 #### Additional tuning tagged find for seriesByTag and autocomplete
-Only one tag used as filter for index field Tag1, see graphite_tagged table [structure](https://github.com/lomik/carbon-clickhouse#clickhouse-configuration)
-
-So, if the first tag in filter is costly (poor selectivity), like environment (with several possible values), query perfomance will be degraded.
-Tune this with `tagged-costs` options:
-
-```
-tagged-costs = {
-    "environment" = { cost: 100 },
-    "project" = { values-cost = { "HugeProject" = 90 } } # overwrite tag value cost for some value only
-}
-```
-
-Default cost is 0 and positive or negative numbers can be used. So if environment is first tag filter in query, it will used as primary only if no other filters with equal operation. Costs from values-cost also applied to regex match or wilrdcarded equal.
-
-## Carbonlink `[carbonlink]`
-The configuration to get metrics from carbon-cache. See details in [graphite-web](https://graphite.readthedocs.io/en/latest/carbon-daemons.html#carbon-relay-py) documentation.
-
-***TODO***: add the real use-case configuration.
-
-## Logging `[logging]`
-It's possible to set multiple loggers. See `Config` description in [config.go](https://github.com/lomik/zapwriter/blob/master/config.go) for details.
-
-## Metrics `[metrics]`
-
-Send internal metrics to graphite relay
- - `metric-endpoint`   - graphite relay address
- - `statsd-endpoint`   - StatsD aggregator address
- - `metric-interval`   - graphite metrics send interval
- - `metric-prefix`     - graphite metrics prefix 
- - `metric-timeout`    - graphite metrics send timeout
- - `ranges`            - separate stat for render query (and internal clickhouse queries) until-from ranges, for example { "1d" = "24h", "7d" = "168h", "90d" = "2160h" }
- - `request-buckets`   - request historgram buckets widths, by default [200, 500, 1000, 2000, 3000, 5000, 7000, 10000, 15000, 20000, 25000, 30000, 40000, 50000, 60000]
- - `request-labels`    - optional request historgram buckets labels
-
-[//]: # (!!!DO NOT EDIT FOLLOWING LINES!!!)
-
-# Example
-
-
+Only one tag used as filter for index field Tag1, see graphite_tagged table [structure](https://github.com/lomik/
 ```toml
 [common]
  # general listener
@@ -280,6 +248,8 @@ Send internal metrics to graphite relay
  tags-max-queries = 0
  # Maximum concurrent queries for tags queries
  tags-max-concurrent = 0
+ # Minimum tags in seriesByTag query
+ tags-min-in-query = 0
 
  # customized query limiter for some users
  # [clickhouse.user-limits]

--- a/finder/base.go
+++ b/finder/base.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/lomik/graphite-clickhouse/config"
 	"github.com/lomik/graphite-clickhouse/helper/clickhouse"
 	"github.com/lomik/graphite-clickhouse/pkg/scope"
 	"github.com/lomik/graphite-clickhouse/pkg/where"
@@ -38,7 +39,7 @@ func (b *BaseFinder) where(query string) *where.Where {
 	return w
 }
 
-func (b *BaseFinder) Execute(ctx context.Context, query string, from int64, until int64, stat *FinderStat) (err error) {
+func (b *BaseFinder) Execute(ctx context.Context, config *config.Config, query string, from int64, until int64, stat *FinderStat) (err error) {
 	w := b.where(query)
 	b.body, stat.ChReadRows, stat.ChReadBytes, err = clickhouse.Query(
 		scope.WithTable(ctx, b.table),

--- a/finder/blacklist.go
+++ b/finder/blacklist.go
@@ -3,6 +3,8 @@ package finder
 import (
 	"context"
 	"regexp"
+
+	"github.com/lomik/graphite-clickhouse/config"
 )
 
 type BlacklistFinder struct {
@@ -18,7 +20,7 @@ func WrapBlacklist(f Finder, blacklist []*regexp.Regexp) *BlacklistFinder {
 	}
 }
 
-func (p *BlacklistFinder) Execute(ctx context.Context, query string, from int64, until int64, stat *FinderStat) (err error) {
+func (p *BlacklistFinder) Execute(ctx context.Context, config *config.Config, query string, from int64, until int64, stat *FinderStat) (err error) {
 	for i := 0; i < len(p.blacklist); i++ {
 		if p.blacklist[i].MatchString(query) {
 			p.matched = true
@@ -26,7 +28,7 @@ func (p *BlacklistFinder) Execute(ctx context.Context, query string, from int64,
 		}
 	}
 
-	return p.wrapped.Execute(ctx, query, from, until, stat)
+	return p.wrapped.Execute(ctx, config, query, from, until, stat)
 }
 
 func (p *BlacklistFinder) List() [][]byte {

--- a/finder/date.go
+++ b/finder/date.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/lomik/graphite-clickhouse/config"
 	"github.com/lomik/graphite-clickhouse/helper/clickhouse"
 	"github.com/lomik/graphite-clickhouse/pkg/scope"
 	"github.com/lomik/graphite-clickhouse/pkg/where"
@@ -29,7 +30,7 @@ func NewDateFinder(url string, table string, tableVersion int, opts clickhouse.O
 	return &DateFinder{b, tableVersion}
 }
 
-func (b *DateFinder) Execute(ctx context.Context, query string, from int64, until int64, stat *FinderStat) (err error) {
+func (b *DateFinder) Execute(ctx context.Context, config *config.Config, query string, from int64, until int64, stat *FinderStat) (err error) {
 	w := b.where(query)
 
 	dateWhere := where.New()

--- a/finder/date_reverse.go
+++ b/finder/date_reverse.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/lomik/graphite-clickhouse/config"
 	"github.com/lomik/graphite-clickhouse/helper/clickhouse"
 	"github.com/lomik/graphite-clickhouse/helper/date"
 	"github.com/lomik/graphite-clickhouse/pkg/scope"
@@ -38,7 +39,7 @@ func (f *DateFinderV3) whereFilter(query string, from int64, until int64) (*wher
 	return w, dateWhere
 }
 
-func (f *DateFinderV3) Execute(ctx context.Context, query string, from int64, until int64, stat *FinderStat) (err error) {
+func (f *DateFinderV3) Execute(ctx context.Context, config *config.Config, query string, from int64, until int64, stat *FinderStat) (err error) {
 	w, dateWhere := f.whereFilter(query, from, until)
 	f.body, stat.ChReadRows, stat.ChReadBytes, err = clickhouse.Query(
 		scope.WithTable(ctx, f.table),

--- a/finder/finder.go
+++ b/finder/finder.go
@@ -25,7 +25,7 @@ type FinderStat struct {
 
 type Finder interface {
 	Result
-	Execute(ctx context.Context, query string, from int64, until int64, stat *FinderStat) error
+	Execute(ctx context.Context, config *config.Config, query string, from int64, until int64, stat *FinderStat) error
 }
 
 func newPlainFinder(ctx context.Context, config *config.Config, query string, from int64, until int64, useCache bool) Finder {
@@ -88,7 +88,7 @@ func newPlainFinder(ctx context.Context, config *config.Config, query string, fr
 
 func Find(config *config.Config, ctx context.Context, query string, from int64, until int64, stat *FinderStat) (Result, error) {
 	fnd := newPlainFinder(ctx, config, query, from, until, config.Common.FindCache != nil)
-	err := fnd.Execute(ctx, query, from, until, stat)
+	err := fnd.Execute(ctx, config, query, from, until, stat)
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +104,7 @@ func Leaf(value []byte) ([]byte, bool) {
 	return value, true
 }
 
-func FindTagged(config *config.Config, ctx context.Context, terms []TaggedTerm, from int64, until int64, stat *FinderStat) (Result, error) {
+func FindTagged(ctx context.Context, config *config.Config, terms []TaggedTerm, from int64, until int64, stat *FinderStat) (Result, error) {
 	opts := clickhouse.Options{
 		Timeout:        config.ClickHouse.IndexTimeout,
 		ConnectTimeout: config.ClickHouse.ConnectTimeout,
@@ -115,7 +115,7 @@ func FindTagged(config *config.Config, ctx context.Context, terms []TaggedTerm, 
 	plain := makePlainFromTagged(terms)
 	if plain != nil {
 		plain.wrappedPlain = newPlainFinder(ctx, config, plain.Target(), from, until, useCache)
-		err := plain.Execute(ctx, plain.Target(), from, until, stat)
+		err := plain.Execute(ctx, config, plain.Target(), from, until, stat)
 		if err != nil {
 			return nil, err
 		}

--- a/finder/index.go
+++ b/finder/index.go
@@ -153,7 +153,7 @@ func (idx *IndexFinder) whereFilter(query string, from int64, until int64) *wher
 	return w
 }
 
-func (idx *IndexFinder) Execute(ctx context.Context, query string, from int64, until int64, stat *FinderStat) (err error) {
+func (idx *IndexFinder) Execute(ctx context.Context, config *config.Config, query string, from int64, until int64, stat *FinderStat) (err error) {
 	w := idx.whereFilter(query, from, until)
 
 	idx.body, stat.ChReadRows, stat.ChReadBytes, err = clickhouse.Query(

--- a/finder/mock.go
+++ b/finder/mock.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"strings"
+
+	"github.com/lomik/graphite-clickhouse/config"
 )
 
 // MockFinder is used for testing purposes
@@ -27,7 +29,7 @@ func NewMockTagged(result [][]byte) *MockFinder {
 }
 
 // Execute assigns given query to the query field
-func (m *MockFinder) Execute(ctx context.Context, query string, from int64, until int64, stat *FinderStat) (err error) {
+func (m *MockFinder) Execute(ctx context.Context, config *config.Config, query string, from int64, until int64, stat *FinderStat) (err error) {
 	m.query = query
 	return
 }

--- a/finder/plain_from_tagged.go
+++ b/finder/plain_from_tagged.go
@@ -6,6 +6,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/lomik/graphite-clickhouse/config"
 )
 
 // Special finder for query plain graphite from prometheus
@@ -62,8 +64,8 @@ func (f *plainFromTaggedFinder) Target() string {
 	return f.target
 }
 
-func (f *plainFromTaggedFinder) Execute(ctx context.Context, query string, from int64, until int64, stat *FinderStat) error {
-	return f.wrappedPlain.Execute(ctx, query, from, until, stat)
+func (f *plainFromTaggedFinder) Execute(ctx context.Context, config *config.Config, query string, from int64, until int64, stat *FinderStat) error {
+	return f.wrappedPlain.Execute(ctx, config, query, from, until, stat)
 }
 
 // For Render

--- a/finder/prefix.go
+++ b/finder/prefix.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/lomik/graphite-clickhouse/config"
 	"github.com/lomik/graphite-clickhouse/pkg/where"
 )
 
@@ -40,7 +41,7 @@ func WrapPrefix(f Finder, prefix string) *PrefixFinder {
 	}
 }
 
-func (p *PrefixFinder) Execute(ctx context.Context, query string, from int64, until int64, stat *FinderStat) error {
+func (p *PrefixFinder) Execute(ctx context.Context, config *config.Config, query string, from int64, until int64, stat *FinderStat) error {
 	qs := strings.Split(query, ".")
 
 	// check regexp
@@ -72,7 +73,7 @@ func (p *PrefixFinder) Execute(ctx context.Context, query string, from int64, un
 
 	p.matched = PrefixMatched
 
-	return p.wrapped.Execute(ctx, strings.Join(qs[len(ps):], "."), from, until, stat)
+	return p.wrapped.Execute(ctx, config, strings.Join(qs[len(ps):], "."), from, until, stat)
 }
 
 func (p *PrefixFinder) List() [][]byte {

--- a/finder/prefix_test.go
+++ b/finder/prefix_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/lomik/graphite-clickhouse/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -36,7 +37,8 @@ func TestPrefixFinderExecute(t *testing.T) {
 		f := WrapPrefix(m, test.prefix)
 
 		var stat FinderStat
-		err := f.Execute(context.Background(), test.query, 0, 0, &stat)
+		config := config.New()
+		err := f.Execute(context.Background(), config, test.query, 0, 0, &stat)
 
 		if test.expectedError {
 			assert.Error(err, testName)
@@ -86,7 +88,8 @@ func TestPrefixFinderList(t *testing.T) {
 		f := WrapPrefix(m, prefix)
 
 		var stat FinderStat
-		f.Execute(context.Background(), test.query, 0, 0, &stat)
+		config := config.New()
+		f.Execute(context.Background(), config, test.query, 0, 0, &stat)
 
 		list := make([]string, 0)
 		for _, r := range f.List() {

--- a/finder/reverse.go
+++ b/finder/reverse.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/lomik/graphite-clickhouse/config"
 	"github.com/lomik/graphite-clickhouse/helper/clickhouse"
 	"github.com/lomik/graphite-clickhouse/pkg/where"
 )
@@ -48,18 +49,18 @@ func WrapReverse(f Finder, url string, table string, opts clickhouse.Options) *R
 	}
 }
 
-func (r *ReverseFinder) Execute(ctx context.Context, query string, from int64, until int64, stat *FinderStat) (err error) {
+func (r *ReverseFinder) Execute(ctx context.Context, config *config.Config, query string, from int64, until int64, stat *FinderStat) (err error) {
 	p := strings.LastIndexByte(query, '.')
 	if p < 0 || p >= len(query)-1 {
-		return r.wrapped.Execute(ctx, query, from, until, stat)
+		return r.wrapped.Execute(ctx, config, query, from, until, stat)
 	}
 
 	if where.HasWildcard(query[p+1:]) {
-		return r.wrapped.Execute(ctx, query, from, until, stat)
+		return r.wrapped.Execute(ctx, config, query, from, until, stat)
 	}
 
 	r.isUsed = true
-	return r.baseFinder.Execute(ctx, ReverseString(query), from, until, stat)
+	return r.baseFinder.Execute(ctx, config, ReverseString(query), from, until, stat)
 }
 
 func (r *ReverseFinder) List() [][]byte {

--- a/finder/tag.go
+++ b/finder/tag.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/lomik/graphite-clickhouse/config"
 	"github.com/lomik/graphite-clickhouse/helper/clickhouse"
 	"github.com/lomik/graphite-clickhouse/pkg/scope"
 	"github.com/lomik/graphite-clickhouse/pkg/where"
@@ -198,20 +199,20 @@ func (t *TagFinder) MakeSQL(query string) (string, error) {
 	return t.seriesSQL()
 }
 
-func (t *TagFinder) Execute(ctx context.Context, query string, from int64, until int64, stat *FinderStat) (err error) {
+func (t *TagFinder) Execute(ctx context.Context, config *config.Config, query string, from int64, until int64, stat *FinderStat) (err error) {
 	t.state = TagSkip
 
 	if query == "" {
-		return t.wrapped.Execute(ctx, query, from, until, stat)
+		return t.wrapped.Execute(ctx, config, query, from, until, stat)
 	}
 
 	if query == "*" {
 		t.state = TagRoot
-		return t.wrapped.Execute(ctx, query, from, until, stat)
+		return t.wrapped.Execute(ctx, config, query, from, until, stat)
 	}
 
 	if !strings.HasPrefix(query, "_tag.") && query != "_tag" {
-		return t.wrapped.Execute(ctx, query, from, until, stat)
+		return t.wrapped.Execute(ctx, config, query, from, until, stat)
 	}
 
 	var sql string

--- a/finder/tag_test.go
+++ b/finder/tag_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/lomik/graphite-clickhouse/config"
 	"github.com/lomik/graphite-clickhouse/helper/clickhouse"
 	chtest "github.com/lomik/graphite-clickhouse/helper/tests/clickhouse"
 )
@@ -103,7 +104,8 @@ func _TestTags(t *testing.T) {
 		f := WrapTag(m, srv.URL, "graphite_tag", clickhouse.Options{Timeout: time.Second, ConnectTimeout: time.Second})
 
 		var stat FinderStat
-		f.Execute(context.Background(), test.query, 0, 0, &stat)
+		config := config.New()
+		f.Execute(context.Background(), config, test.query, 0, 0, &stat)
 
 		list := make([]string, 0)
 		for _, r := range f.List() {

--- a/helper/clickhouse/clickhouse.go
+++ b/helper/clickhouse/clickhouse.go
@@ -103,7 +103,7 @@ func HandleError(w http.ResponseWriter, err error) (status int, queueFail bool) 
 		}
 		return
 	}
-	errCode, ok := err.(*errs.ErrorWithCode)
+	errCode, ok := err.(errs.ErrorWithCode)
 	if ok {
 		if (errCode.Code > 500 && errCode.Code < 512) ||
 			errCode.Code == http.StatusBadRequest || errCode.Code == http.StatusForbidden {

--- a/helper/errs/errors.go
+++ b/helper/errs/errors.go
@@ -8,11 +8,11 @@ type ErrorWithCode struct {
 }
 
 func NewErrorWithCode(err string, code int) error {
-	return &ErrorWithCode{err, code}
+	return ErrorWithCode{err, code}
 }
 
 func NewErrorfWithCode(code int, f string, args ...interface{}) error {
-	return &ErrorWithCode{fmt.Sprintf(f, args...), code}
+	return ErrorWithCode{fmt.Sprintf(f, args...), code}
 }
 
-func (e *ErrorWithCode) Error() string { return e.err }
+func (e ErrorWithCode) Error() string { return e.err }

--- a/prometheus/querier_select.go
+++ b/prometheus/querier_select.go
@@ -44,7 +44,7 @@ func (q *Querier) lookup(from, until int64, qlimiter limiter.ServerLimiter, queu
 		defer qlimiter.Leave(limitCtx, "render")
 	}
 	// TODO: implement use stat for Prometheus queries
-	fndResult, err := finder.FindTagged(q.config, q.ctx, terms, from, until, &stat)
+	fndResult, err := finder.FindTagged(q.ctx, q.config, terms, from, until, &stat)
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
On large setup some requests like 
 `seriesByTag('name=~test.*.*.rabbitmq_overview.connections')` or `seriesByTag('name=test.*.*.rabbitmq_overview.connections')`
may be too costly. Yes, this a bad pattern, but we need a way restrict bad queries before execution query and max_read_rows limit for reduce database load.
