### PR TITLE
Fixed incorrect finder behaviour with extra-prefix specified

### DIFF
--- a/finder/index.go
+++ b/finder/index.go
@@ -178,7 +178,11 @@ func (idx *IndexFinder) Abs(v []byte) []byte {
 }
 
 func (idx *IndexFinder) bodySplit() {
-	idx.rows = bytes.Split(idx.body, []byte{'\n'})
+	if len(idx.body) == 0 {
+		return
+	}
+
+	idx.rows = bytes.Split(bytes.TrimSuffix(idx.body, []byte{'\n'}), []byte{'\n'})
 
 	if idx.useReverse("") {
 		// rotate names for reduce


### PR DESCRIPTION
```
extra-prefix = "extra"

# curl -s 'http://127.0.0.1:19010/metrics/find?query=*' | jq .
[
  {
    "allowChildren": 1,
    "expandable": 1,
    "leaf": 0,
    "id": "extra",
    "text": "extra",
    "context": {}
  }
]

# curl -s 'http://127.0.0.1:19010/metrics/find?query=extra.*' | jq .
[
  {
    "allowChildren": 1,
    "expandable": 1,
    "leaf": 0,
    "id": "extra.carbon",
    "text": "carbon",
    "context": {}
  },
  {
    "allowChildren": 1,
    "expandable": 1,
    "leaf": 0,
    "id": "extra.extra",
    "text": "extra",
    "context": {}
  }
]

# curl -s 'http://127.0.0.1:19010/metrics/find?query=extra.extra.*' | jq .
[
  {
    "allowChildren": 1,
    "expandable": 1,
    "leaf": 0,
    "id": "extra.extra.extra",
    "text": "extra",
    "context": {}
  }
]

# curl -s 'http://127.0.0.1:19010/metrics/find?query=extra.notexits.*' | jq .
[
  {
    "allowChildren": 1,
    "expandable": 1,
    "leaf": 0,
    "id": "extra.notexits.extra",
    "text": "extra",
    "context": {}
  }
]
```