### PR TITLE
index.json: Properly escape json strings.

### DIFF
--- a/index/index.go
+++ b/index/index.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -81,12 +82,13 @@ func (i *Index) WriteJSON(w http.ResponseWriter) error {
 			continue
 		}
 
-		quote := []byte{'"'}
+		json_b, err := json.Marshal(string(b))
+		if err != nil {
+			return err
+		}
 		jsonParts := [][]byte{
 			nil,
-			quote,
-			b,
-			quote,
+			json_b,
 		}
 		if idx != 0 {
 			jsonParts[0] = []byte{','}

--- a/index/index_test.go
+++ b/index/index_test.go
@@ -43,7 +43,7 @@ func TestWriteJSONNonleafRows(t *testing.T) {
 	if len(metrics) != 3 {
 		t.Fatalf("Wrong metrics slice length = %d: %s", len(metrics), metrics)
 	}
-	if metrics[0] != "testing.leaf" || metrics[1] != "testing.leaf.node" {
+	if metrics[0] != "testing.leaf" || metrics[1] != "testing.leaf.node" || metrics[2] != "testing.\"broken\".node" {
 		t.Fatalf("Wrong metrics contents: %s", metrics)
 	}
 }

--- a/index/index_test.go
+++ b/index/index_test.go
@@ -34,12 +34,13 @@ func TestWriteJSONNonleafRows(t *testing.T) {
 		"testing.leaf",
 		"testing.nonleaf.",
 		"testing.leaf.node",
+		"testing.\"broken\".node",
 	}
 	metrics, err := writeRows(rows)
 	if err != nil {
 		t.Fatalf("Error during transform or unmarshal: %s", err)
 	}
-	if len(metrics) != 2 {
+	if len(metrics) != 3 {
 		t.Fatalf("Wrong metrics slice length = %d: %s", len(metrics), metrics)
 	}
 	if metrics[0] != "testing.leaf" || metrics[1] != "testing.leaf.node" {


### PR DESCRIPTION
Although most likely not officially supported, we might end up with some weird metric names in the DB. icinga2 is a good candidate for a source of broken metrics.

Add a simple test like and marshal the strings properly.