### PR TITLE
feat(config): add -exact-config command line argument

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -320,7 +320,7 @@ sample-initial = 10
 sample-thereafter = 12
 `,
 	)
-	config, _, err := Unmarshal(body)
+	config, _, err := Unmarshal(body, false)
 	expected := New()
 	require.NoError(t, err)
 
@@ -554,7 +554,7 @@ sample-initial = 10
 sample-thereafter = 12
 `,
 	)
-	config, _, err := Unmarshal(body)
+	config, _, err := Unmarshal(body, false)
 	expected := New()
 	require.NoError(t, err)
 	assert.NotNil(t, metrics.Graphite)
@@ -868,7 +868,7 @@ sample-initial = 10
 sample-thereafter = 12
 `,
 	)
-	config, _, err := Unmarshal(body)
+	config, _, err := Unmarshal(body, false)
 	expected := New()
 	require.NoError(t, err)
 	assert.NotNil(t, metrics.Graphite)
@@ -1072,7 +1072,7 @@ func TestGetQueryParamBroken(t *testing.T) {
 			  },
 			]`)
 
-	_, _, err := Unmarshal(config)
+	_, _, err := Unmarshal(config, false)
 	assert.Error(t, err)
 
 	config =
@@ -1087,7 +1087,7 @@ func TestGetQueryParamBroken(t *testing.T) {
 			  },
 			]`)
 
-	_, _, err = Unmarshal(config)
+	_, _, err = Unmarshal(config, false)
 	assert.Error(t, err)
 }
 
@@ -1250,7 +1250,7 @@ func TestGetQueryParam(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if config, _, err := Unmarshal(tt.config); err == nil {
+			if config, _, err := Unmarshal(tt.config, false); err == nil {
 				for i := range config.ClickHouse.QueryParams {
 					config.ClickHouse.QueryParams[i].Limiter = nil
 				}

--- a/graphite-clickhouse.go
+++ b/graphite-clickhouse.go
@@ -100,6 +100,7 @@ func main() {
 	configFile := flag.String("config", "/etc/graphite-clickhouse/graphite-clickhouse.conf", "Filename of config")
 	printDefaultConfig := flag.Bool("config-print-default", false, "Print default config")
 	checkConfig := flag.Bool("check-config", false, "Check config and exit")
+	exactConfig := flag.Bool("exact-config", false, "Ensure that all config params are contained in the target struct.")
 	buildTags := flag.Bool("tags", false, "Build tags table")
 	pprof := flag.String(
 		"pprof",
@@ -130,7 +131,7 @@ func main() {
 		return
 	}
 
-	cfg, warns, err := config.ReadConfig(*configFile)
+	cfg, warns, err := config.ReadConfig(*configFile, *exactConfig)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This PR adds the "-exact-config" command line argument which ensures that all parameters in a config file are contained inside the corresponding struct.
If you run e2e tests with this, they are going to fail since "max-metrics-in-render-answer" does not exist inside the "Common" struct.