### PR TITLE
Add filter support to prometheus for /api/v1/labels /api/v1/{label}/values

### DIFF
--- a/prometheus/querier.go
+++ b/prometheus/querier.go
@@ -100,6 +100,7 @@ func (q *Querier) LabelNames(matchers ...*labels.Matcher) ([]string, storage.War
 		}
 		w.And(and)
 	}
+	w.And("value != '__name__'")
 	fromDate := time.Now().AddDate(0, 0, -q.config.ClickHouse.TaggedAutocompleDays).UTC()
 	w.Andf("Date >= '%s'", fromDate.Format("2006-01-02"))
 

--- a/prometheus/querier.go
+++ b/prometheus/querier.go
@@ -17,7 +17,6 @@ import (
 	"github.com/lomik/graphite-clickhouse/helper/clickhouse"
 	"github.com/lomik/graphite-clickhouse/pkg/scope"
 	"github.com/lomik/graphite-clickhouse/pkg/where"
-	// "github.com/lomik/graphite-clickhouse/pkg/where"
 )
 
 // Querier provides reading access to time series data.

--- a/prometheus/querier.go
+++ b/prometheus/querier.go
@@ -34,7 +34,6 @@ func (q *Querier) Close() error {
 
 // LabelValues returns all potential values for a label name.
 func (q *Querier) LabelValues(label string, matchers ...*labels.Matcher) ([]string, storage.Warnings, error) {
-	// @TODO: support matchers
 	terms := []finder.TaggedTerm{
 		{
 			Key:         label,
@@ -54,7 +53,6 @@ func (q *Querier) LabelValues(label string, matchers ...*labels.Matcher) ([]stri
 	if err != nil {
 		return nil, nil, err
 	}
-	//wr.And(where.HasPrefix("Tag1", label+"="))
 
 	fromDate := timeNow().AddDate(0, 0, -q.config.ClickHouse.TaggedAutocompleDays)
 	wr.Andf("Date >= '%s'", fromDate.Format("2006-01-02"))
@@ -89,12 +87,12 @@ func (q *Querier) LabelValues(label string, matchers ...*labels.Matcher) ([]stri
 
 // LabelNames returns all the unique label names present in the block in sorted order.
 func (q *Querier) LabelNames(matchers ...*labels.Matcher) ([]string, storage.Warnings, error) {
-	// @TODO support matchers
 	terms, err := makeTaggedFromPromQL(matchers)
 	if err != nil {
 		return nil, nil, err
 	}
 	w := where.New()
+	// @TODO: this is duplicate to the for in finder.TaggedWhere. (different start...)
 	for i := 0; i < len(terms); i++ {
 		and, err := finder.TaggedTermWhereN(&terms[i])
 		if err != nil {

--- a/prometheus/querier.go
+++ b/prometheus/querier.go
@@ -13,9 +13,11 @@ import (
 	"github.com/prometheus/prometheus/storage"
 
 	"github.com/lomik/graphite-clickhouse/config"
+	"github.com/lomik/graphite-clickhouse/finder"
 	"github.com/lomik/graphite-clickhouse/helper/clickhouse"
 	"github.com/lomik/graphite-clickhouse/pkg/scope"
 	"github.com/lomik/graphite-clickhouse/pkg/where"
+	// "github.com/lomik/graphite-clickhouse/pkg/where"
 )
 
 // Querier provides reading access to time series data.
@@ -34,15 +36,33 @@ func (q *Querier) Close() error {
 // LabelValues returns all potential values for a label name.
 func (q *Querier) LabelValues(label string, matchers ...*labels.Matcher) ([]string, storage.Warnings, error) {
 	// @TODO: support matchers
-	w := where.New()
-	w.And(where.HasPrefix("Tag1", label+"="))
+	terms := []finder.TaggedTerm{
+		{
+			Key:         label,
+			Op:          finder.TaggedTermEq,
+			Value:       "*",
+			HasWildcard: true,
+		},
+	}
+
+	matcherTerms, err := makeTaggedFromPromQL(matchers)
+	if err != nil {
+		return nil, nil, err
+	}
+	terms = append(terms, matcherTerms...)
+	
+	wr, _, err := finder.TaggedWhere(terms)
+	if err != nil {
+		return nil, nil, err
+	}
+	//wr.And(where.HasPrefix("Tag1", label+"="))
 
 	fromDate := timeNow().AddDate(0, 0, -q.config.ClickHouse.TaggedAutocompleDays)
-	w.Andf("Date >= '%s'", fromDate.Format("2006-01-02"))
+	wr.Andf("Date >= '%s'", fromDate.Format("2006-01-02"))
 
 	sql := fmt.Sprintf("SELECT splitByChar('=', Tag1)[2] as value FROM %s %s GROUP BY value ORDER BY value",
 		q.config.ClickHouse.TaggedTable,
-		w.SQL(),
+		wr.SQL(),
 	)
 
 	body, _, _, err := clickhouse.Query(
@@ -71,7 +91,18 @@ func (q *Querier) LabelValues(label string, matchers ...*labels.Matcher) ([]stri
 // LabelNames returns all the unique label names present in the block in sorted order.
 func (q *Querier) LabelNames(matchers ...*labels.Matcher) ([]string, storage.Warnings, error) {
 	// @TODO support matchers
+	terms, err := makeTaggedFromPromQL(matchers)
+	if err != nil {
+		return nil, nil, err
+	}
 	w := where.New()
+	for i := 0; i < len(terms); i++ {
+		and, err := finder.TaggedTermWhereN(&terms[i])
+		if err != nil {
+			return nil, nil, err
+		}
+		w.And(and)
+	}
 	fromDate := time.Now().AddDate(0, 0, -q.config.ClickHouse.TaggedAutocompleDays).UTC()
 	w.Andf("Date >= '%s'", fromDate.Format("2006-01-02"))
 

--- a/prometheus/querier.go
+++ b/prometheus/querier.go
@@ -36,7 +36,7 @@ func (q *Querier) Close() error {
 func (q *Querier) LabelValues(label string, matchers ...*labels.Matcher) ([]string, storage.Warnings, error) {
 	terms := []finder.TaggedTerm{
 		{
-			Key:         label,
+			Key:         strings.ReplaceAll(label, `_`, `\_`),
 			Op:          finder.TaggedTermEq,
 			Value:       "*",
 			HasWildcard: true,

--- a/prometheus/querier.go
+++ b/prometheus/querier.go
@@ -100,7 +100,6 @@ func (q *Querier) LabelNames(matchers ...*labels.Matcher) ([]string, storage.War
 		}
 		w.And(and)
 	}
-	w.And("value != '__name__'")
 	fromDate := time.Now().AddDate(0, 0, -q.config.ClickHouse.TaggedAutocompleDays).UTC()
 	w.Andf("Date >= '%s'", fromDate.Format("2006-01-02"))
 


### PR DESCRIPTION
Not sure if my implementation is really ideal. Atm the querier.go of prometheus does not supprt filter support for metric and label searches. please review if what I do is really ok :)

This pull request implements the following changes:

1. Ensure that the matchers are matched against the Tags Array/Column.
2. For LabelNames() the matchers are performed against the Tags array column (by using index.TaggedTermWhereN)
3. For LabelValues() the same is done + LIKE __name__=% is added as a where condition for Tag1.

If no matchers are provided graphite-clickhouse should work exactly like before.

If a matcher is provided it is matched against the Tags column.

In our case we use the stack with multi tenant support. So a proxy before graphite-clickhouse performs authentication and injects a label into all requests. {x=y}. 

This change ensures that LabelNames() and LabelValues() only returns results which match {x=y}