### PR TITLE
change clickhouse version from 23.12 to 24.2

### DIFF
--- a/issues/daytime/test.toml
+++ b/issues/daytime/test.toml
@@ -2,7 +2,7 @@
 precision = "10s"
 
 [[test.clickhouse]]
-version = "23.12"
+version = "latest"
 dir = "tests/clickhouse/rollup"
 
 [test.carbon_clickhouse]

--- a/issues/daytime/test.toml
+++ b/issues/daytime/test.toml
@@ -2,7 +2,7 @@
 precision = "10s"
 
 [[test.clickhouse]]
-version = "latest"
+version = "24.2"
 dir = "tests/clickhouse/rollup"
 
 [test.carbon_clickhouse]

--- a/tests/agg_internal/test.toml
+++ b/tests/agg_internal/test.toml
@@ -10,7 +10,7 @@ version = "22.8"
 dir = "tests/clickhouse/rollup"
 
 [[test.clickhouse]]
-version = "23.12"
+version = "latest"
 dir = "tests/clickhouse/rollup"
 
 [test.carbon_clickhouse]

--- a/tests/agg_internal/test.toml
+++ b/tests/agg_internal/test.toml
@@ -10,7 +10,7 @@ version = "22.8"
 dir = "tests/clickhouse/rollup"
 
 [[test.clickhouse]]
-version = "latest"
+version = "24.2"
 dir = "tests/clickhouse/rollup"
 
 [test.carbon_clickhouse]

--- a/tests/agg_latest/test.toml
+++ b/tests/agg_latest/test.toml
@@ -18,7 +18,7 @@ version = "22.8"
 dir = "tests/clickhouse/rollup"
 
 [[test.clickhouse]]
-version = "latest"
+version = "24.2"
 dir = "tests/clickhouse/rollup"
 
 [test.carbon_clickhouse]

--- a/tests/agg_latest/test.toml
+++ b/tests/agg_latest/test.toml
@@ -18,7 +18,7 @@ version = "22.8"
 dir = "tests/clickhouse/rollup"
 
 [[test.clickhouse]]
-version = "23.12"
+version = "latest"
 dir = "tests/clickhouse/rollup"
 
 [test.carbon_clickhouse]

--- a/tests/agg_merge/test.toml
+++ b/tests/agg_merge/test.toml
@@ -10,7 +10,7 @@ version = "22.8"
 dir = "tests/clickhouse/rollup"
 
 [[test.clickhouse]]
-version = "23.12"
+version = "latest"
 dir = "tests/clickhouse/rollup"
 
 [test.carbon_clickhouse]

--- a/tests/agg_merge/test.toml
+++ b/tests/agg_merge/test.toml
@@ -10,7 +10,7 @@ version = "22.8"
 dir = "tests/clickhouse/rollup"
 
 [[test.clickhouse]]
-version = "latest"
+version = "24.2"
 dir = "tests/clickhouse/rollup"
 
 [test.carbon_clickhouse]

--- a/tests/agg_oneblock/test.toml
+++ b/tests/agg_oneblock/test.toml
@@ -10,7 +10,7 @@ version = "22.8"
 dir = "tests/clickhouse/rollup"
 
 [[test.clickhouse]]
-version = "23.12"
+version = "latest"
 dir = "tests/clickhouse/rollup"
 
 [test.carbon_clickhouse]

--- a/tests/agg_oneblock/test.toml
+++ b/tests/agg_oneblock/test.toml
@@ -10,7 +10,7 @@ version = "22.8"
 dir = "tests/clickhouse/rollup"
 
 [[test.clickhouse]]
-version = "latest"
+version = "24.2"
 dir = "tests/clickhouse/rollup"
 
 [test.carbon_clickhouse]

--- a/tests/emptyseries_append/test.toml
+++ b/tests/emptyseries_append/test.toml
@@ -10,7 +10,7 @@ version = "22.8"
 dir = "tests/clickhouse/rollup"
 
 [[test.clickhouse]]
-version = "23.12"
+version = "latest"
 dir = "tests/clickhouse/rollup"
 
 [test.carbon_clickhouse]

--- a/tests/emptyseries_append/test.toml
+++ b/tests/emptyseries_append/test.toml
@@ -10,7 +10,7 @@ version = "22.8"
 dir = "tests/clickhouse/rollup"
 
 [[test.clickhouse]]
-version = "latest"
+version = "24.2"
 dir = "tests/clickhouse/rollup"
 
 [test.carbon_clickhouse]

--- a/tests/emptyseries_noappend/test.toml
+++ b/tests/emptyseries_noappend/test.toml
@@ -10,7 +10,7 @@ version = "22.8"
 dir = "tests/clickhouse/rollup"
 
 [[test.clickhouse]]
-version = "23.12"
+version = "latest"
 dir = "tests/clickhouse/rollup"
 
 [test.carbon_clickhouse]

--- a/tests/emptyseries_noappend/test.toml
+++ b/tests/emptyseries_noappend/test.toml
@@ -10,7 +10,7 @@ version = "22.8"
 dir = "tests/clickhouse/rollup"
 
 [[test.clickhouse]]
-version = "latest"
+version = "24.2"
 dir = "tests/clickhouse/rollup"
 
 [test.carbon_clickhouse]

--- a/tests/error_handling/test.toml
+++ b/tests/error_handling/test.toml
@@ -2,7 +2,7 @@
 precision = "10s"
 
 [[test.clickhouse]]
-version = "23.12"
+version = "latest"
 dir = "tests/clickhouse/rollup"
 
 [test.carbon_clickhouse]

--- a/tests/error_handling/test.toml
+++ b/tests/error_handling/test.toml
@@ -2,7 +2,7 @@
 precision = "10s"
 
 [[test.clickhouse]]
-version = "latest"
+version = "24.2"
 dir = "tests/clickhouse/rollup"
 
 [test.carbon_clickhouse]

--- a/tests/find_cache/test.toml
+++ b/tests/find_cache/test.toml
@@ -2,7 +2,7 @@
 precision = "10s"
 
 [[test.clickhouse]]
-version = "23.12"
+version = "latest"
 dir = "tests/clickhouse/rollup"
 delay = "10s"
 

--- a/tests/find_cache/test.toml
+++ b/tests/find_cache/test.toml
@@ -2,7 +2,7 @@
 precision = "10s"
 
 [[test.clickhouse]]
-version = "latest"
+version = "24.2"
 dir = "tests/clickhouse/rollup"
 delay = "10s"
 

--- a/tests/limitera/test.toml
+++ b/tests/limitera/test.toml
@@ -2,7 +2,7 @@
 precision = "10s"
 
 [[test.clickhouse]]
-version = "23.12"
+version = "latest"
 dir = "tests/clickhouse/rollup"
 delay = "10s"
 

--- a/tests/limitera/test.toml
+++ b/tests/limitera/test.toml
@@ -2,7 +2,7 @@
 precision = "10s"
 
 [[test.clickhouse]]
-version = "latest"
+version = "24.2"
 dir = "tests/clickhouse/rollup"
 delay = "10s"
 

--- a/tests/limitermax/test.toml
+++ b/tests/limitermax/test.toml
@@ -2,7 +2,7 @@
 precision = "10s"
 
 [[test.clickhouse]]
-version = "23.12"
+version = "latest"
 dir = "tests/clickhouse/rollup"
 delay = "10s"
 

--- a/tests/limitermax/test.toml
+++ b/tests/limitermax/test.toml
@@ -2,7 +2,7 @@
 precision = "10s"
 
 [[test.clickhouse]]
-version = "latest"
+version = "24.2"
 dir = "tests/clickhouse/rollup"
 delay = "10s"
 

--- a/tests/limiterw/test.toml
+++ b/tests/limiterw/test.toml
@@ -2,7 +2,7 @@
 precision = "10s"
 
 [[test.clickhouse]]
-version = "23.12"
+version = "latest"
 dir = "tests/clickhouse/rollup"
 delay = "10s"
 

--- a/tests/limiterw/test.toml
+++ b/tests/limiterw/test.toml
@@ -2,7 +2,7 @@
 precision = "10s"
 
 [[test.clickhouse]]
-version = "latest"
+version = "24.2"
 dir = "tests/clickhouse/rollup"
 delay = "10s"
 

--- a/tests/limiterwn/test.toml
+++ b/tests/limiterwn/test.toml
@@ -2,7 +2,7 @@
 precision = "10s"
 
 [[test.clickhouse]]
-version = "23.12"
+version = "latest"
 dir = "tests/clickhouse/rollup"
 delay = "10s"
 

--- a/tests/limiterwn/test.toml
+++ b/tests/limiterwn/test.toml
@@ -2,7 +2,7 @@
 precision = "10s"
 
 [[test.clickhouse]]
-version = "latest"
+version = "24.2"
 dir = "tests/clickhouse/rollup"
 delay = "10s"
 

--- a/tests/one_table/test.toml
+++ b/tests/one_table/test.toml
@@ -10,7 +10,7 @@ version = "22.8"
 dir = "tests/clickhouse/rollup"
 
 [[test.clickhouse]]
-version = "23.12"
+version = "latest"
 dir = "tests/clickhouse/rollup"
 
 [test.carbon_clickhouse]

--- a/tests/one_table/test.toml
+++ b/tests/one_table/test.toml
@@ -10,7 +10,7 @@ version = "22.8"
 dir = "tests/clickhouse/rollup"
 
 [[test.clickhouse]]
-version = "latest"
+version = "24.2"
 dir = "tests/clickhouse/rollup"
 
 [test.carbon_clickhouse]

--- a/tests/tls/test.toml
+++ b/tests/tls/test.toml
@@ -12,7 +12,7 @@ tls = true
 dir = "tests/clickhouse/rollup_tls"
 
 [[test.clickhouse]]
-version = "latest"
+version = "24.2"
 tls = true
 dir = "tests/clickhouse/rollup_tls"
 

--- a/tests/tls/test.toml
+++ b/tests/tls/test.toml
@@ -12,7 +12,7 @@ tls = true
 dir = "tests/clickhouse/rollup_tls"
 
 [[test.clickhouse]]
-version = "23.12"
+version = "latest"
 tls = true
 dir = "tests/clickhouse/rollup_tls"
 


### PR DESCRIPTION
Seems to fix the issue with e2e tests failing.