### PR TITLE
fix: set correct clickhouse aggregation functions when using consolidateBy

### DIFF
--- a/cmd/e2e-test/checks.go
+++ b/cmd/e2e-test/checks.go
@@ -310,7 +310,7 @@ func verifyRender(ch *Clickhouse, gch *GraphiteClickhouse, check *RenderCheck, d
 			}
 		}
 
-		if url, result, respHeader, err := client.Render(&httpClient, address, format, check.Targets, filteringFunctions, from, until); err == nil {
+		if url, result, respHeader, err := client.Render(&httpClient, address, format, check.Targets, filteringFunctions, check.MaxDataPoints, from, until); err == nil {
 			id := requestId(respHeader)
 			name := ""
 			if check.ErrorRegexp != "" {
@@ -333,7 +333,7 @@ func verifyRender(ch *Clickhouse, gch *GraphiteClickhouse, check *RenderCheck, d
 			if check.CacheTTL > 0 && check.ErrorRegexp == "" {
 				// second query must be find-cached
 				name = "cache"
-				if url, result, respHeader, err = client.Render(&httpClient, address, format, check.Targets, filteringFunctions, from, until); err == nil {
+				if url, result, respHeader, err = client.Render(&httpClient, address, format, check.Targets, filteringFunctions, check.MaxDataPoints, from, until); err == nil {
 					compareRender(&errors, name, url, result, check.result, true, respHeader, check.CacheTTL)
 				} else {
 					errStr := strings.TrimRight(err.Error(), "\n")

--- a/cmd/e2e-test/checks.go
+++ b/cmd/e2e-test/checks.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-graphite/protocol/carbonapi_v3_pb"
 	"github.com/lomik/graphite-clickhouse/helper/client"
 	"github.com/lomik/graphite-clickhouse/helper/datetime"
 	"github.com/lomik/graphite-clickhouse/helper/tests/compare"
@@ -271,6 +272,24 @@ func compareRender(errors *[]string, name, url string, actual, expected []client
 	}
 }
 
+func parseFilteringFunctions(strFilteringFuncs []string) ([]*carbonapi_v3_pb.FilteringFunction, error) {
+	res := make([]*carbonapi_v3_pb.FilteringFunction, 0, len(strFilteringFuncs))
+	for _, strFF := range strFilteringFuncs {
+		strFFSplit := strings.Split(strFF, "(")
+		if len(strFFSplit) != 2 {
+			return nil, fmt.Errorf("could not parse filtering function: %s", strFF)
+		}
+		name := strFFSplit[0]
+		args := strings.Split(strFFSplit[1], ",")
+		for i := range args {
+			args[i] = strings.TrimSpace(args[i])
+			args[i] = strings.Trim(args[i], ")'")
+		}
+		res = append(res, &carbonapi_v3_pb.FilteringFunction{Name: name, Arguments: args})
+	}
+	return res, nil
+}
+
 func verifyRender(ch *Clickhouse, gch *GraphiteClickhouse, check *RenderCheck, defaultPreision time.Duration) []string {
 	var errors []string
 	httpClient := http.Client{
@@ -280,7 +299,18 @@ func verifyRender(ch *Clickhouse, gch *GraphiteClickhouse, check *RenderCheck, d
 	from := datetime.TimestampTruncate(check.from, defaultPreision)
 	until := datetime.TimestampTruncate(check.until, defaultPreision)
 	for _, format := range check.Formats {
-		if url, result, respHeader, err := client.Render(&httpClient, address, format, check.Targets, from, until); err == nil {
+
+		var filteringFunctions []*carbonapi_v3_pb.FilteringFunction
+		if format == client.FormatPb_v3 {
+			var err error
+			filteringFunctions, err = parseFilteringFunctions(check.FilteringFunctions)
+			if err != nil {
+				errors = append(errors, err.Error())
+				continue
+			}
+		}
+
+		if url, result, respHeader, err := client.Render(&httpClient, address, format, check.Targets, filteringFunctions, from, until); err == nil {
 			id := requestId(respHeader)
 			name := ""
 			if check.ErrorRegexp != "" {
@@ -303,7 +333,7 @@ func verifyRender(ch *Clickhouse, gch *GraphiteClickhouse, check *RenderCheck, d
 			if check.CacheTTL > 0 && check.ErrorRegexp == "" {
 				// second query must be find-cached
 				name = "cache"
-				if url, result, respHeader, err = client.Render(&httpClient, address, format, check.Targets, from, until); err == nil {
+				if url, result, respHeader, err = client.Render(&httpClient, address, format, check.Targets, filteringFunctions, from, until); err == nil {
 					compareRender(&errors, name, url, result, check.result, true, respHeader, check.CacheTTL)
 				} else {
 					errStr := strings.TrimRight(err.Error(), "\n")

--- a/cmd/e2e-test/e2etesting.go
+++ b/cmd/e2e-test/e2etesting.go
@@ -59,13 +59,14 @@ type Metric struct {
 }
 
 type RenderCheck struct {
-	Name        string              `toml:"name"`
-	Formats     []client.FormatType `toml:"formats"`
-	From        string              `toml:"from"`
-	Until       string              `toml:"until"`
-	Targets     []string            `toml:"targets"`
-	Timeout     time.Duration       `toml:"timeout"`
-	DumpIfEmpty []string            `toml:"dump_if_empty"`
+	Name               string              `toml:"name"`
+	Formats            []client.FormatType `toml:"formats"`
+	From               string              `toml:"from"`
+	Until              string              `toml:"until"`
+	Targets            []string            `toml:"targets"`
+	FilteringFunctions []string            `toml:"filtering_functions"`
+	Timeout            time.Duration       `toml:"timeout"`
+	DumpIfEmpty        []string            `toml:"dump_if_empty"`
 
 	Optimize []string `toml:"optimize"` // optimize tables before run tests
 
@@ -338,6 +339,7 @@ func verifyGraphiteClickhouse(test *TestSchema, gch *GraphiteClickhouse, clickho
 						zap.String("clickhouse config", clickhouseDir),
 						zap.String("graphite-clickhouse config", gch.ConfigTpl),
 						zap.Strings("targets", check.Targets),
+						zap.Strings("filtering_functions", check.FilteringFunctions),
 						zap.String("from_raw", check.From),
 						zap.String("until_raw", check.Until),
 						zap.Int64("from", check.from),
@@ -361,6 +363,7 @@ func verifyGraphiteClickhouse(test *TestSchema, gch *GraphiteClickhouse, clickho
 				zap.String("clickhouse config", clickhouseDir),
 				zap.String("graphite-clickhouse config", gch.ConfigTpl),
 				zap.Strings("targets", check.Targets),
+				zap.Strings("filtering_functions", check.FilteringFunctions),
 				zap.String("from_raw", check.From),
 				zap.String("until_raw", check.Until),
 				zap.Int64("from", check.from),
@@ -377,6 +380,7 @@ func verifyGraphiteClickhouse(test *TestSchema, gch *GraphiteClickhouse, clickho
 				zap.String("clickhouse config", clickhouseDir),
 				zap.String("graphite-clickhouse config", gch.ConfigTpl),
 				zap.Strings("targets", check.Targets),
+				zap.Strings("filtering_functions", check.FilteringFunctions),
 				zap.String("from_raw", check.From),
 				zap.String("until_raw", check.Until),
 				zap.Int64("from", check.from),

--- a/cmd/e2e-test/e2etesting.go
+++ b/cmd/e2e-test/e2etesting.go
@@ -64,6 +64,7 @@ type RenderCheck struct {
 	From               string              `toml:"from"`
 	Until              string              `toml:"until"`
 	Targets            []string            `toml:"targets"`
+	MaxDataPoints      int64               `toml:"max_data_points"`
 	FilteringFunctions []string            `toml:"filtering_functions"`
 	Timeout            time.Duration       `toml:"timeout"`
 	DumpIfEmpty        []string            `toml:"dump_if_empty"`

--- a/cmd/graphite-clickhouse-client/main.go
+++ b/cmd/graphite-clickhouse-client/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -32,6 +33,7 @@ func main() {
 	address := flag.String("address", "http://127.0.0.1:9090", "Address of graphite-clickhouse server")
 	fromStr := flag.String("from", "0", "from")
 	untilStr := flag.String("until", "", "until")
+	maxDataPointsStr := flag.String("maxDataPoints", "1048576", "Maximum amount of datapoints in response")
 
 	metricsFind := flag.String("find", "", "Query for /metrics/find/ , valid formats are carbonapi_v3_pb. protobuf, pickle")
 
@@ -70,6 +72,11 @@ func main() {
 	until = datetime.DateParamToEpoch(*untilStr, tz, now, 0)
 	if until == 0 && len(targets) > 0 {
 		fmt.Printf("invalid until: %s\n", *untilStr)
+		os.Exit(1)
+	}
+	maxDataPoints, err := strconv.ParseInt(*maxDataPointsStr, 10, 64)
+	if err != nil {
+		fmt.Printf("invalid maxDataPoints: %s\n", *maxDataPointsStr)
 		os.Exit(1)
 	}
 
@@ -183,7 +190,7 @@ func main() {
 		if formatRender == client.FormatDefault {
 			formatRender = client.FormatPb_v3
 		}
-		queryRaw, r, respHeader, err := client.Render(&httpClient, *address, formatRender, targets, []*carbonapi_v3_pb.FilteringFunction{}, int64(from), int64(until))
+		queryRaw, r, respHeader, err := client.Render(&httpClient, *address, formatRender, targets, []*carbonapi_v3_pb.FilteringFunction{}, maxDataPoints, int64(from), int64(until))
 		if respHeader != nil {
 			fmt.Printf("Responce header: %+v\n", respHeader)
 		}

--- a/cmd/graphite-clickhouse-client/main.go
+++ b/cmd/graphite-clickhouse-client/main.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-graphite/protocol/carbonapi_v3_pb"
 	"github.com/lomik/graphite-clickhouse/helper/client"
 	"github.com/lomik/graphite-clickhouse/helper/datetime"
 )
@@ -182,7 +183,7 @@ func main() {
 		if formatRender == client.FormatDefault {
 			formatRender = client.FormatPb_v3
 		}
-		queryRaw, r, respHeader, err := client.Render(&httpClient, *address, formatRender, targets, int64(from), int64(until))
+		queryRaw, r, respHeader, err := client.Render(&httpClient, *address, formatRender, targets, []*carbonapi_v3_pb.FilteringFunction{}, int64(from), int64(until))
 		if respHeader != nil {
 			fmt.Printf("Responce header: %+v\n", respHeader)
 		}

--- a/helper/client/render.go
+++ b/helper/client/render.go
@@ -37,7 +37,7 @@ type Metric struct {
 
 // Render do /metrics/find/ request
 // Valid formats are carbonapi_v3_pb. protobuf, pickle, json
-func Render(client *http.Client, address string, format FormatType, targets []string, filteringFunctions []*protov3.FilteringFunction, from, until int64) (string, []Metric, http.Header, error) {
+func Render(client *http.Client, address string, format FormatType, targets []string, filteringFunctions []*protov3.FilteringFunction, maxDataPoints, from, until int64) (string, []Metric, http.Header, error) {
 	rUrl := "/render/"
 	if format == FormatDefault {
 		format = FormatPb_v3
@@ -56,6 +56,7 @@ func Render(client *http.Client, address string, format FormatType, targets []st
 	}
 	fromStr := strconv.FormatInt(from, 10)
 	untilStr := strconv.FormatInt(until, 10)
+	maxDataPointsStr := strconv.FormatInt(maxDataPoints, 10)
 
 	u, err := url.Parse(address + rUrl)
 	if err != nil {
@@ -82,6 +83,7 @@ func Render(client *http.Client, address string, format FormatType, targets []st
 				StopTime:        until,
 				PathExpression:  target,
 				FilterFunctions: filteringFunctions,
+				MaxDataPoints:   maxDataPoints,
 			}
 		}
 
@@ -94,10 +96,11 @@ func Render(client *http.Client, address string, format FormatType, targets []st
 		}
 	case FormatPb_v2, FormatProtobuf, FormatPickle, FormatJSON:
 		v := url.Values{
-			"format": []string{format.String()},
-			"from":   []string{fromStr},
-			"until":  []string{untilStr},
-			"target": targets,
+			"format":        []string{format.String()},
+			"from":          []string{fromStr},
+			"until":         []string{untilStr},
+			"target":        targets,
+			"maxDataPoints": []string{maxDataPointsStr},
 		}
 		u.RawQuery = v.Encode()
 	default:

--- a/helper/client/render.go
+++ b/helper/client/render.go
@@ -37,7 +37,7 @@ type Metric struct {
 
 // Render do /metrics/find/ request
 // Valid formats are carbonapi_v3_pb. protobuf, pickle, json
-func Render(client *http.Client, address string, format FormatType, targets []string, from, until int64) (string, []Metric, http.Header, error) {
+func Render(client *http.Client, address string, format FormatType, targets []string, filteringFunctions []*protov3.FilteringFunction, from, until int64) (string, []Metric, http.Header, error) {
 	rUrl := "/render/"
 	if format == FormatDefault {
 		format = FormatPb_v3
@@ -77,10 +77,11 @@ func Render(client *http.Client, address string, format FormatType, targets []st
 		}
 		for i, target := range targets {
 			r.Metrics[i] = protov3.FetchRequest{
-				Name:           target,
-				StartTime:      from,
-				StopTime:       until,
-				PathExpression: target,
+				Name:            target,
+				StartTime:       from,
+				StopTime:        until,
+				PathExpression:  target,
+				FilterFunctions: filteringFunctions,
 			}
 		}
 

--- a/render/data/data.go
+++ b/render/data/data.go
@@ -59,8 +59,9 @@ func (d *Data) GetAggregation(id uint32) (string, error) {
 		return "first", nil
 	case "anyLast":
 		return "last", nil
+	default:
+		return function, nil
 	}
-	return function, nil
 }
 
 // data wraps Data and adds asynchronous processing of data

--- a/render/data/data.go
+++ b/render/data/data.go
@@ -54,7 +54,10 @@ func (d *Data) GetAggregation(id uint32) (string, error) {
 	if err != nil {
 		return function, err
 	}
-	if function == "any" || function == "anyLast" {
+	switch function {
+	case "any":
+		return "first", nil
+	case "anyLast":
 		return "last", nil
 	}
 	return function, nil

--- a/render/data/targets.go
+++ b/render/data/targets.go
@@ -139,13 +139,22 @@ func (tt *Targets) GetRequestedAggregation(target string) string {
 			ffName := filteringFunc.GetName()
 			ffArgs := filteringFunc.GetArguments()
 			if ffName == graphiteConsolidationFunction && len(ffArgs) > 0 {
+				switch ffArgs[0] {
+				// 'last' in graphite == clickhouse aggregate function 'anyLast'
+				case "last":
+					return "anyLast"
+				// 'first' in graphite == clickhouse aggregate function 'any'
+				case "first":
+					return "any"
 				// Graphite standard supports both average and avg.
 				// It is the only aggregation that has two aliases.
 				// https://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.consolidateBy
-				if ffArgs[0] == "average" {
+				case "average":
 					return "avg"
+				// avg, sum, max, min have the same name in clickhouse
+				default:
+					return ffArgs[0]
 				}
-				return ffArgs[0]
 			}
 		}
 	}

--- a/render/data/targets.go
+++ b/render/data/targets.go
@@ -131,32 +131,47 @@ TableLoop:
 	return fmt.Errorf("data tables is not specified for %v", tt.List[0])
 }
 
-func (tt *Targets) GetRequestedAggregation(target string) string {
+func (tt *Targets) GetRequestedAggregation(target string) (string, error) {
 	if ffs, ok := tt.filteringFunctionsByTarget[target]; !ok {
-		return ""
+		return "", nil
 	} else {
 		for _, filteringFunc := range ffs {
 			ffName := filteringFunc.GetName()
 			ffArgs := filteringFunc.GetArguments()
-			if ffName == graphiteConsolidationFunction && len(ffArgs) > 0 {
-				switch ffArgs[0] {
-				// 'last' in graphite == clickhouse aggregate function 'anyLast'
-				case "last":
-					return "anyLast"
-				// 'first' in graphite == clickhouse aggregate function 'any'
-				case "first":
-					return "any"
-				// Graphite standard supports both average and avg.
-				// It is the only aggregation that has two aliases.
-				// https://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.consolidateBy
-				case "average":
-					return "avg"
-				// avg, sum, max, min have the same name in clickhouse
-				default:
-					return ffArgs[0]
-				}
+
+			if ffName != graphiteConsolidationFunction {
+				continue
+			}
+
+			if len(ffArgs) < 1 {
+				return "", fmt.Errorf("no argumets were provided to consolidateBy function")
+			}
+
+			switch ffArgs[0] {
+			// 'last' in graphite == clickhouse aggregate function 'anyLast'
+			case "last":
+				return "anyLast", nil
+			// 'first' in graphite == clickhouse aggregate function 'any'
+			case "first":
+				return "any", nil
+			// Graphite standard supports both average and avg.
+			// It is the only aggregation that has two aliases.
+			// https://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.consolidateBy
+			case "average":
+				return "avg", nil
+			// avg, sum, max, min have the same name in clickhouse
+			case "avg", "sum", "max", "min":
+				return ffArgs[0], nil
+			default:
+				return "",
+					fmt.Errorf(
+						"unknown \"%s\" argument function (allowed argumets are: 'avg', 'average', 'sum', 'max', 'min', 'last', 'first'): recieved %s",
+						graphiteConsolidationFunction,
+						ffArgs[0],
+					)
+
 			}
 		}
 	}
-	return ""
+	return "", nil
 }

--- a/tests/consolidateBy/carbon-clickhouse.conf.tpl
+++ b/tests/consolidateBy/carbon-clickhouse.conf.tpl
@@ -1,0 +1,45 @@
+[common]
+
+[data]
+path = "/etc/carbon-clickhouse/data"
+chunk-interval = "1s"
+chunk-auto-interval = ""
+
+[upload.graphite_index]
+type = "index"
+table = "graphite_index"
+url = "{{ .CLICKHOUSE_URL }}/"
+timeout = "2m30s"
+cache-ttl = "1h"
+
+[upload.graphite_tags]
+type = "tagged"
+table = "graphite_tags"
+threads = 3
+url = "{{ .CLICKHOUSE_URL }}/"
+timeout = "2m30s"
+cache-ttl = "1h"
+
+[upload.graphite_reverse]
+type = "points-reverse"
+table = "graphite_reverse"
+url = "{{ .CLICKHOUSE_URL }}/"
+timeout = "2m30s"
+zero-timestamp = false
+
+[upload.graphite]
+type = "points"
+table = "graphite"
+url = "{{ .CLICKHOUSE_URL }}/"
+timeout = "2m30s"
+zero-timestamp = false
+
+[tcp]
+listen = ":2003"
+enabled = true
+drop-future = "0s"
+drop-past = "0s"
+
+[logging]
+file = "/etc/carbon-clickhouse/carbon-clickhouse.log"
+level = "debug"

--- a/tests/consolidateBy/graphite-clickhouse.conf.tpl
+++ b/tests/consolidateBy/graphite-clickhouse.conf.tpl
@@ -1,0 +1,37 @@
+[common]
+listen = "{{ .GCH_ADDR }}"
+max-cpu = 0
+max-metrics-in-render-answer = 10000
+max-metrics-per-target = 10000
+headers-to-log = [ "X-Ctx-Carbonapi-Uuid" ]
+
+[feature-flags]
+use-carbon-behaviour = false
+dont-match-missing-tags = true
+
+[clickhouse]
+url = "{{ .CLICKHOUSE_URL }}/?max_rows_to_read=500000000&max_result_bytes=1073741824&readonly=2&log_queries=1"
+data-timeout = "30s"
+
+index-table = "graphite_index"
+index-use-daily = true
+index-timeout = "1m"
+internal-aggregation = true
+
+tagged-table = "graphite_tags"
+tagged-autocomplete-days = 1
+
+[[data-table]]
+# # clickhouse table name
+table = "graphite"
+# # points in table are stored with reverse path
+reverse = false
+rollup-conf = "auto"
+
+[[logging]]
+logger = ""
+file = "{{ .GCH_DIR }}/graphite-clickhouse.log"
+level = "info"
+encoding = "json"
+encoding-time = "iso8601"
+encoding-duration = "seconds"

--- a/tests/consolidateBy/test.toml
+++ b/tests/consolidateBy/test.toml
@@ -302,4 +302,4 @@ targets = [
 filtering_functions = [
     "consolidateBy('invalid')"
 ]
-error_regexp = "^500: Storage error"
+error_regexp = "^400: failed to choose appropriate aggregation"

--- a/tests/consolidateBy/test.toml
+++ b/tests/consolidateBy/test.toml
@@ -1,0 +1,297 @@
+[test]
+precision = "10s"
+
+[[test.clickhouse]]
+version = "21.3"
+dir = "tests/clickhouse/rollup"
+
+[[test.clickhouse]]
+version = "22.8"
+dir = "tests/clickhouse/rollup"
+
+[[test.clickhouse]]
+version = "24.2"
+dir = "tests/clickhouse/rollup"
+
+[test.carbon_clickhouse]
+template = "carbon-clickhouse.conf.tpl"
+
+[[test.graphite_clickhouse]]
+template = "graphite-clickhouse.conf.tpl"
+
+#######################################################################################
+
+[[test.input]]
+name = "request_success_total.counter;app=test;project=Test;environment=TEST"
+points = [{value = 1.0, time = "rnow-10"}]
+
+[[test.input]]
+name = "request_success_total.counter;app=test;project=Test;environment=TEST;t=q"
+points = [{value = 1.0, time = "rnow-10"}]
+
+[[test.input]]
+name = "test;env=prod"
+points = [{value = 1.0, time = "rnow-10"}]
+
+[[test.input]]
+name = "test;env=dr"
+points = [{value = 1.0, time = "rnow-10"}]
+
+# consolidateBy('max')
+
+[[test.render_checks]]
+from = "rnow-10"
+until = "rnow+1"
+timeout = "1h"
+targets = [ 
+    "seriesByTag('name=request_success_total.counter', 'app=test', 'project=Test', 'environment=TEST')", 
+]
+filtering_functions = [
+    "consolidateBy('max')"
+]
+
+[[test.render_checks.result]]
+name = "request_success_total.counter;app=test;environment=TEST;project=Test"
+path = "seriesByTag('name=request_success_total.counter', 'app=test', 'project=Test', 'environment=TEST')"
+consolidation = "max"
+start = "rnow-10"
+stop = "rnow+10"
+step = 10
+req_start = "rnow-10"
+req_stop = "rnow+10"
+values = [1.0, nan]
+
+[[test.render_checks.result]]
+name = "request_success_total.counter;app=test;environment=TEST;project=Test;t=q"
+path = "seriesByTag('name=request_success_total.counter', 'app=test', 'project=Test', 'environment=TEST')"
+consolidation = "max"
+start = "rnow-10"
+stop = "rnow+10"
+step = 10
+req_start = "rnow-10"
+req_stop = "rnow+10"
+values = [1.0, nan]
+
+# consolidateBy('min')
+
+[[test.render_checks]]
+from = "rnow-10"
+until = "rnow+1"
+timeout = "1h"
+targets = [ 
+    "seriesByTag('name=request_success_total.counter', 'app=test', 'project=Test', 'environment=TEST')", 
+]
+filtering_functions = [
+    "consolidateBy('min')"
+]
+
+[[test.render_checks.result]]
+name = "request_success_total.counter;app=test;environment=TEST;project=Test"
+path = "seriesByTag('name=request_success_total.counter', 'app=test', 'project=Test', 'environment=TEST')"
+consolidation = "min"
+start = "rnow-10"
+stop = "rnow+10"
+step = 10
+req_start = "rnow-10"
+req_stop = "rnow+10"
+values = [1.0, nan]
+
+[[test.render_checks.result]]
+name = "request_success_total.counter;app=test;environment=TEST;project=Test;t=q"
+path = "seriesByTag('name=request_success_total.counter', 'app=test', 'project=Test', 'environment=TEST')"
+consolidation = "min"
+start = "rnow-10"
+stop = "rnow+10"
+step = 10
+req_start = "rnow-10"
+req_stop = "rnow+10"
+values = [1.0, nan]
+
+# consolidateBy('sum')
+
+[[test.render_checks]]
+from = "rnow-10"
+until = "rnow+1"
+timeout = "1h"
+targets = [ 
+    "seriesByTag('name=request_success_total.counter', 'app=test', 'project=Test', 'environment=TEST')", 
+]
+filtering_functions = [
+    "consolidateBy('sum')"
+]
+
+[[test.render_checks.result]]
+name = "request_success_total.counter;app=test;environment=TEST;project=Test"
+path = "seriesByTag('name=request_success_total.counter', 'app=test', 'project=Test', 'environment=TEST')"
+consolidation = "sum"
+start = "rnow-10"
+stop = "rnow+10"
+step = 10
+req_start = "rnow-10"
+req_stop = "rnow+10"
+values = [1.0, nan]
+
+[[test.render_checks.result]]
+name = "request_success_total.counter;app=test;environment=TEST;project=Test;t=q"
+path = "seriesByTag('name=request_success_total.counter', 'app=test', 'project=Test', 'environment=TEST')"
+consolidation = "sum"
+start = "rnow-10"
+stop = "rnow+10"
+step = 10
+req_start = "rnow-10"
+req_stop = "rnow+10"
+values = [1.0, nan]
+
+# consolidateBy('avg')
+
+[[test.render_checks]]
+from = "rnow-10"
+until = "rnow+1"
+timeout = "1h"
+targets = [ 
+    "seriesByTag('name=request_success_total.counter', 'app=test', 'project=Test', 'environment=TEST')", 
+]
+filtering_functions = [
+    "consolidateBy('avg')"
+]
+
+[[test.render_checks.result]]
+name = "request_success_total.counter;app=test;environment=TEST;project=Test"
+path = "seriesByTag('name=request_success_total.counter', 'app=test', 'project=Test', 'environment=TEST')"
+consolidation = "avg"
+start = "rnow-10"
+stop = "rnow+10"
+step = 10
+req_start = "rnow-10"
+req_stop = "rnow+10"
+values = [1.0, nan]
+
+[[test.render_checks.result]]
+name = "request_success_total.counter;app=test;environment=TEST;project=Test;t=q"
+path = "seriesByTag('name=request_success_total.counter', 'app=test', 'project=Test', 'environment=TEST')"
+consolidation = "avg"
+start = "rnow-10"
+stop = "rnow+10"
+step = 10
+req_start = "rnow-10"
+req_stop = "rnow+10"
+values = [1.0, nan]
+
+# consolidateBy('average')
+
+[[test.render_checks]]
+from = "rnow-10"
+until = "rnow+1"
+timeout = "1h"
+targets = [ 
+    "seriesByTag('name=request_success_total.counter', 'app=test', 'project=Test', 'environment=TEST')", 
+]
+filtering_functions = [
+    "consolidateBy('average')"
+]
+
+[[test.render_checks.result]]
+name = "request_success_total.counter;app=test;environment=TEST;project=Test"
+path = "seriesByTag('name=request_success_total.counter', 'app=test', 'project=Test', 'environment=TEST')"
+consolidation = "avg"
+start = "rnow-10"
+stop = "rnow+10"
+step = 10
+req_start = "rnow-10"
+req_stop = "rnow+10"
+values = [1.0, nan]
+
+[[test.render_checks.result]]
+name = "request_success_total.counter;app=test;environment=TEST;project=Test;t=q"
+path = "seriesByTag('name=request_success_total.counter', 'app=test', 'project=Test', 'environment=TEST')"
+consolidation = "avg"
+start = "rnow-10"
+stop = "rnow+10"
+step = 10
+req_start = "rnow-10"
+req_stop = "rnow+10"
+values = [1.0, nan]
+
+# consolidateBy('last')
+
+[[test.render_checks]]
+from = "rnow-10"
+until = "rnow+1"
+timeout = "1h"
+targets = [ 
+    "seriesByTag('name=request_success_total.counter', 'app=test', 'project=Test', 'environment=TEST')", 
+]
+filtering_functions = [
+    "consolidateBy('last')"
+]
+
+[[test.render_checks.result]]
+name = "request_success_total.counter;app=test;environment=TEST;project=Test"
+path = "seriesByTag('name=request_success_total.counter', 'app=test', 'project=Test', 'environment=TEST')"
+consolidation = "last"
+start = "rnow-10"
+stop = "rnow+10"
+step = 10
+req_start = "rnow-10"
+req_stop = "rnow+10"
+values = [1.0, nan]
+
+[[test.render_checks.result]]
+name = "request_success_total.counter;app=test;environment=TEST;project=Test;t=q"
+path = "seriesByTag('name=request_success_total.counter', 'app=test', 'project=Test', 'environment=TEST')"
+consolidation = "last"
+start = "rnow-10"
+stop = "rnow+10"
+step = 10
+req_start = "rnow-10"
+req_stop = "rnow+10"
+values = [1.0, nan]
+
+# consolidateBy('first')
+
+[[test.render_checks]]
+from = "rnow-10"
+until = "rnow+1"
+timeout = "1h"
+targets = [ 
+    "seriesByTag('name=request_success_total.counter', 'app=test', 'project=Test', 'environment=TEST')", 
+]
+filtering_functions = [
+    "consolidateBy('first')"
+]
+
+[[test.render_checks.result]]
+name = "request_success_total.counter;app=test;environment=TEST;project=Test"
+path = "seriesByTag('name=request_success_total.counter', 'app=test', 'project=Test', 'environment=TEST')"
+consolidation = "first"
+start = "rnow-10"
+stop = "rnow+10"
+step = 10
+req_start = "rnow-10"
+req_stop = "rnow+10"
+values = [1.0, nan]
+
+[[test.render_checks.result]]
+name = "request_success_total.counter;app=test;environment=TEST;project=Test;t=q"
+path = "seriesByTag('name=request_success_total.counter', 'app=test', 'project=Test', 'environment=TEST')"
+consolidation = "first"
+start = "rnow-10"
+stop = "rnow+10"
+step = 10
+req_start = "rnow-10"
+req_stop = "rnow+10"
+values = [1.0, nan]
+
+# consolidateBy('invalid')
+
+[[test.render_checks]]
+from = "rnow-10"
+until = "rnow+1"
+timeout = "1h"
+targets = [ 
+    "seriesByTag('name=request_success_total.counter', 'app=test', 'project=Test', 'environment=TEST')", 
+]
+filtering_functions = [
+    "consolidateBy('invalid')"
+]
+error_regexp = "^500: Storage error"

--- a/tests/consolidateBy/test.toml
+++ b/tests/consolidateBy/test.toml
@@ -23,25 +23,26 @@ template = "graphite-clickhouse.conf.tpl"
 
 [[test.input]]
 name = "request_success_total.counter;app=test;project=Test;environment=TEST"
-points = [{value = 1.0, time = "rnow-10"}]
+points = [{value = 3.0, time = "1000"}, {value = 0.0, time = "1010"}, {value = 1.0, time = "1020"}, {value = 2.0, time = "1030"}]
 
 [[test.input]]
 name = "request_success_total.counter;app=test;project=Test;environment=TEST;t=q"
-points = [{value = 1.0, time = "rnow-10"}]
+points = [{value = 3.0, time = "1000"}, {value = 0.0, time = "1010"}, {value = 1.0, time = "1020"}, {value = 2.0, time = "1030"}]
 
 [[test.input]]
 name = "test;env=prod"
-points = [{value = 1.0, time = "rnow-10"}]
+points = [{value = 3.0, time = "1000"}, {value = 0.0, time = "1010"}, {value = 1.0, time = "1020"}, {value = 2.0, time = "1030"}]
 
 [[test.input]]
 name = "test;env=dr"
-points = [{value = 1.0, time = "rnow-10"}]
+points = [{value = 3.0, time = "1000"}, {value = 0.0, time = "1010"}, {value = 1.0, time = "1020"}, {value = 2.0, time = "1030"}]
 
 # consolidateBy('max')
 
 [[test.render_checks]]
-from = "rnow-10"
-until = "rnow+1"
+from = "1000"
+until = "1030"
+max_data_points = 2
 timeout = "1h"
 targets = [ 
     "seriesByTag('name=request_success_total.counter', 'app=test', 'project=Test', 'environment=TEST')", 
@@ -54,29 +55,30 @@ filtering_functions = [
 name = "request_success_total.counter;app=test;environment=TEST;project=Test"
 path = "seriesByTag('name=request_success_total.counter', 'app=test', 'project=Test', 'environment=TEST')"
 consolidation = "max"
-start = "rnow-10"
-stop = "rnow+10"
-step = 10
-req_start = "rnow-10"
-req_stop = "rnow+10"
-values = [1.0, nan]
+start = "1000"
+stop = "1040"
+step = 20
+req_start = "1000"
+req_stop = "1040"
+values = [3.0, 2.0]
 
 [[test.render_checks.result]]
 name = "request_success_total.counter;app=test;environment=TEST;project=Test;t=q"
 path = "seriesByTag('name=request_success_total.counter', 'app=test', 'project=Test', 'environment=TEST')"
 consolidation = "max"
-start = "rnow-10"
-stop = "rnow+10"
-step = 10
-req_start = "rnow-10"
-req_stop = "rnow+10"
-values = [1.0, nan]
+start = "1000"
+stop = "1040"
+step = 20
+req_start = "1000"
+req_stop = "1040"
+values = [3.0, 2.0]
 
 # consolidateBy('min')
 
 [[test.render_checks]]
-from = "rnow-10"
-until = "rnow+1"
+from = "1000"
+until = "1030"
+max_data_points = 2
 timeout = "1h"
 targets = [ 
     "seriesByTag('name=request_success_total.counter', 'app=test', 'project=Test', 'environment=TEST')", 
@@ -89,29 +91,31 @@ filtering_functions = [
 name = "request_success_total.counter;app=test;environment=TEST;project=Test"
 path = "seriesByTag('name=request_success_total.counter', 'app=test', 'project=Test', 'environment=TEST')"
 consolidation = "min"
-start = "rnow-10"
-stop = "rnow+10"
-step = 10
-req_start = "rnow-10"
-req_stop = "rnow+10"
-values = [1.0, nan]
+start = "1000"
+stop = "1040"
+step = 20
+req_start = "1000"
+req_stop = "1040"
+values = [0.0, 1.0]
 
 [[test.render_checks.result]]
 name = "request_success_total.counter;app=test;environment=TEST;project=Test;t=q"
 path = "seriesByTag('name=request_success_total.counter', 'app=test', 'project=Test', 'environment=TEST')"
 consolidation = "min"
-start = "rnow-10"
-stop = "rnow+10"
-step = 10
-req_start = "rnow-10"
-req_stop = "rnow+10"
-values = [1.0, nan]
+start = "1000"
+stop = "1040"
+step = 20
+req_start = "1000"
+req_stop = "1040"
+values = [0.0, 1.0]
+
 
 # consolidateBy('sum')
 
 [[test.render_checks]]
-from = "rnow-10"
-until = "rnow+1"
+from = "1000"
+until = "1030"
+max_data_points = 2
 timeout = "1h"
 targets = [ 
     "seriesByTag('name=request_success_total.counter', 'app=test', 'project=Test', 'environment=TEST')", 
@@ -124,29 +128,30 @@ filtering_functions = [
 name = "request_success_total.counter;app=test;environment=TEST;project=Test"
 path = "seriesByTag('name=request_success_total.counter', 'app=test', 'project=Test', 'environment=TEST')"
 consolidation = "sum"
-start = "rnow-10"
-stop = "rnow+10"
-step = 10
-req_start = "rnow-10"
-req_stop = "rnow+10"
-values = [1.0, nan]
+start = "1000"
+stop = "1040"
+step = 20
+req_start = "1000"
+req_stop = "1040"
+values = [3.0, 3.0]
 
 [[test.render_checks.result]]
 name = "request_success_total.counter;app=test;environment=TEST;project=Test;t=q"
 path = "seriesByTag('name=request_success_total.counter', 'app=test', 'project=Test', 'environment=TEST')"
 consolidation = "sum"
-start = "rnow-10"
-stop = "rnow+10"
-step = 10
-req_start = "rnow-10"
-req_stop = "rnow+10"
-values = [1.0, nan]
+start = "1000"
+stop = "1040"
+step = 20
+req_start = "1000"
+req_stop = "1040"
+values = [3.0, 3.0]
 
 # consolidateBy('avg')
 
 [[test.render_checks]]
-from = "rnow-10"
-until = "rnow+1"
+from = "1000"
+until = "1030"
+max_data_points = 2
 timeout = "1h"
 targets = [ 
     "seriesByTag('name=request_success_total.counter', 'app=test', 'project=Test', 'environment=TEST')", 
@@ -159,29 +164,30 @@ filtering_functions = [
 name = "request_success_total.counter;app=test;environment=TEST;project=Test"
 path = "seriesByTag('name=request_success_total.counter', 'app=test', 'project=Test', 'environment=TEST')"
 consolidation = "avg"
-start = "rnow-10"
-stop = "rnow+10"
-step = 10
-req_start = "rnow-10"
-req_stop = "rnow+10"
-values = [1.0, nan]
+start = "1000"
+stop = "1040"
+step = 20
+req_start = "1000"
+req_stop = "1040"
+values = [1.5, 1.5]
 
 [[test.render_checks.result]]
 name = "request_success_total.counter;app=test;environment=TEST;project=Test;t=q"
 path = "seriesByTag('name=request_success_total.counter', 'app=test', 'project=Test', 'environment=TEST')"
 consolidation = "avg"
-start = "rnow-10"
-stop = "rnow+10"
-step = 10
-req_start = "rnow-10"
-req_stop = "rnow+10"
-values = [1.0, nan]
+start = "1000"
+stop = "1040"
+step = 20
+req_start = "1000"
+req_stop = "1040"
+values = [1.5, 1.5]
 
 # consolidateBy('average')
 
 [[test.render_checks]]
-from = "rnow-10"
-until = "rnow+1"
+from = "1000"
+until = "1030"
+max_data_points = 2
 timeout = "1h"
 targets = [ 
     "seriesByTag('name=request_success_total.counter', 'app=test', 'project=Test', 'environment=TEST')", 
@@ -194,29 +200,30 @@ filtering_functions = [
 name = "request_success_total.counter;app=test;environment=TEST;project=Test"
 path = "seriesByTag('name=request_success_total.counter', 'app=test', 'project=Test', 'environment=TEST')"
 consolidation = "avg"
-start = "rnow-10"
-stop = "rnow+10"
-step = 10
-req_start = "rnow-10"
-req_stop = "rnow+10"
-values = [1.0, nan]
+start = "1000"
+stop = "1040"
+step = 20
+req_start = "1000"
+req_stop = "1040"
+values = [1.5, 1.5]
 
 [[test.render_checks.result]]
 name = "request_success_total.counter;app=test;environment=TEST;project=Test;t=q"
 path = "seriesByTag('name=request_success_total.counter', 'app=test', 'project=Test', 'environment=TEST')"
 consolidation = "avg"
-start = "rnow-10"
-stop = "rnow+10"
-step = 10
-req_start = "rnow-10"
-req_stop = "rnow+10"
-values = [1.0, nan]
+start = "1000"
+stop = "1040"
+step = 20
+req_start = "1000"
+req_stop = "1040"
+values = [1.5, 1.5]
 
 # consolidateBy('last')
 
 [[test.render_checks]]
-from = "rnow-10"
-until = "rnow+1"
+from = "1000"
+until = "1030"
+max_data_points = 2
 timeout = "1h"
 targets = [ 
     "seriesByTag('name=request_success_total.counter', 'app=test', 'project=Test', 'environment=TEST')", 
@@ -229,29 +236,30 @@ filtering_functions = [
 name = "request_success_total.counter;app=test;environment=TEST;project=Test"
 path = "seriesByTag('name=request_success_total.counter', 'app=test', 'project=Test', 'environment=TEST')"
 consolidation = "last"
-start = "rnow-10"
-stop = "rnow+10"
-step = 10
-req_start = "rnow-10"
-req_stop = "rnow+10"
-values = [1.0, nan]
+start = "1000"
+stop = "1040"
+step = 20
+req_start = "1000"
+req_stop = "1040"
+values = [0.0, 2.0]
 
 [[test.render_checks.result]]
 name = "request_success_total.counter;app=test;environment=TEST;project=Test;t=q"
 path = "seriesByTag('name=request_success_total.counter', 'app=test', 'project=Test', 'environment=TEST')"
 consolidation = "last"
-start = "rnow-10"
-stop = "rnow+10"
-step = 10
-req_start = "rnow-10"
-req_stop = "rnow+10"
-values = [1.0, nan]
+start = "1000"
+stop = "1040"
+step = 20
+req_start = "1000"
+req_stop = "1040"
+values = [0.0, 2.0]
 
 # consolidateBy('first')
 
 [[test.render_checks]]
-from = "rnow-10"
-until = "rnow+1"
+from = "1000"
+until = "1030"
+max_data_points = 2
 timeout = "1h"
 targets = [ 
     "seriesByTag('name=request_success_total.counter', 'app=test', 'project=Test', 'environment=TEST')", 
@@ -264,29 +272,29 @@ filtering_functions = [
 name = "request_success_total.counter;app=test;environment=TEST;project=Test"
 path = "seriesByTag('name=request_success_total.counter', 'app=test', 'project=Test', 'environment=TEST')"
 consolidation = "first"
-start = "rnow-10"
-stop = "rnow+10"
-step = 10
-req_start = "rnow-10"
-req_stop = "rnow+10"
-values = [1.0, nan]
+start = "1000"
+stop = "1040"
+step = 20
+req_start = "1000"
+req_stop = "1040"
+values = [3.0, 1.0]
 
 [[test.render_checks.result]]
 name = "request_success_total.counter;app=test;environment=TEST;project=Test;t=q"
 path = "seriesByTag('name=request_success_total.counter', 'app=test', 'project=Test', 'environment=TEST')"
 consolidation = "first"
-start = "rnow-10"
-stop = "rnow+10"
-step = 10
-req_start = "rnow-10"
-req_stop = "rnow+10"
-values = [1.0, nan]
+start = "1000"
+stop = "1040"
+step = 20
+req_start = "1000"
+req_stop = "1040"
+values = [3.0, 1.0]
 
 # consolidateBy('invalid')
 
 [[test.render_checks]]
-from = "rnow-10"
-until = "rnow+1"
+from = "1000"
+until = "1030"
 timeout = "1h"
 targets = [ 
     "seriesByTag('name=request_success_total.counter', 'app=test', 'project=Test', 'environment=TEST')", 


### PR DESCRIPTION
Fixes a case where consolidateBy function is used with an argument 'first' or 'last' which causes graphite-clickhouse to return "500 Storage error" since aggregate functions are named differently in clickhouse.