### PR TITLE
Make terms with equality and empty values in seriesByTag count as if they have a wildcard when using use-carbon-behaviour

### DIFF
--- a/finder/tagged.go
+++ b/finder/tagged.go
@@ -291,7 +291,10 @@ func ParseTaggedConditions(conditions []string, config *config.Config, autocompl
 		case "=":
 			terms[i].Op = TaggedTermEq
 			terms[i].HasWildcard = where.HasWildcard(terms[i].Value)
-			if !terms[i].HasWildcard {
+			// special case when using useCarbonBehaviour = true
+			// which matches everything that does not have that tag
+			emptyValue := config.FeatureFlags.UseCarbonBehavior && terms[i].Value == ""
+			if !terms[i].HasWildcard && !emptyValue {
 				nonWildcards++
 			}
 		case "!=":

--- a/tests/tags_min_in_query/carbon-clickhouse.conf.tpl
+++ b/tests/tags_min_in_query/carbon-clickhouse.conf.tpl
@@ -1,0 +1,45 @@
+[common]
+
+[data]
+path = "/etc/carbon-clickhouse/data"
+chunk-interval = "1s"
+chunk-auto-interval = ""
+
+[upload.graphite_index]
+type = "index"
+table = "graphite_index"
+url = "{{ .CLICKHOUSE_URL }}/"
+timeout = "2m30s"
+cache-ttl = "1h"
+
+[upload.graphite_tags]
+type = "tagged"
+table = "graphite_tags"
+threads = 3
+url = "{{ .CLICKHOUSE_URL }}/"
+timeout = "2m30s"
+cache-ttl = "1h"
+
+[upload.graphite_reverse]
+type = "points-reverse"
+table = "graphite_reverse"
+url = "{{ .CLICKHOUSE_URL }}/"
+timeout = "2m30s"
+zero-timestamp = false
+
+[upload.graphite]
+type = "points"
+table = "graphite"
+url = "{{ .CLICKHOUSE_URL }}/"
+timeout = "2m30s"
+zero-timestamp = false
+
+[tcp]
+listen = ":2003"
+enabled = true
+drop-future = "0s"
+drop-past = "0s"
+
+[logging]
+file = "/etc/carbon-clickhouse/carbon-clickhouse.log"
+level = "debug"

--- a/tests/tags_min_in_query/graphite-clickhouse.conf.tpl
+++ b/tests/tags_min_in_query/graphite-clickhouse.conf.tpl
@@ -1,0 +1,38 @@
+[common]
+listen = "{{ .GCH_ADDR }}"
+max-cpu = 0
+max-metrics-in-render-answer = 10000
+max-metrics-per-target = 10000
+headers-to-log = [ "X-Ctx-Carbonapi-Uuid" ]
+
+[feature-flags]
+use-carbon-behaviour = true
+
+[clickhouse]
+url = "{{ .CLICKHOUSE_URL }}/?max_rows_to_read=500000000&max_result_bytes=1073741824&readonly=2&log_queries=1"
+data-timeout = "30s"
+
+index-table = "graphite_index"
+index-use-daily = true
+index-timeout = "1m"
+internal-aggregation = true
+
+tagged-table = "graphite_tags"
+tagged-autocomplete-days = 1
+
+tags-min-in-query = 1
+
+[[data-table]]
+# # clickhouse table name
+table = "graphite"
+# # points in table are stored with reverse path
+reverse = false
+rollup-conf = "auto"
+
+[[logging]]
+logger = ""
+file = "{{ .GCH_DIR }}/graphite-clickhouse.log"
+level = "info"
+encoding = "json"
+encoding-time = "iso8601"
+encoding-duration = "seconds"

--- a/tests/tags_min_in_query/test.toml
+++ b/tests/tags_min_in_query/test.toml
@@ -1,0 +1,159 @@
+[test]
+precision = "10s"
+
+[[test.clickhouse]]
+version = "21.3"
+dir = "tests/clickhouse/rollup"
+
+[[test.clickhouse]]
+version = "22.8"
+dir = "tests/clickhouse/rollup"
+
+[[test.clickhouse]]
+version = "24.2"
+dir = "tests/clickhouse/rollup"
+
+[test.carbon_clickhouse]
+template = "carbon-clickhouse.conf.tpl"
+
+[[test.graphite_clickhouse]]
+template = "graphite-clickhouse.conf.tpl"
+
+#######################################################################################
+
+[[test.input]]
+name = "test;env=prod"
+points = [{value = 1.0, time = "rnow-10"}]
+
+[[test.input]]
+name = "test;env=dev"
+points = [{value = 1.0, time = "rnow-10"}]
+
+[[test.input]]
+name = "test;env=stage"
+points = [{value = 1.0, time = "rnow-10"}]
+
+[[test.render_checks]]
+from = "rnow-10"
+until = "rnow+1"
+timeout = "1h"
+targets = [ 
+    "seriesByTag('name=test')", 
+]
+
+[[test.render_checks.result]]
+name = "test;env=prod"
+path = "seriesByTag('name=test')"
+consolidation = "avg"
+start = "rnow-10"
+stop = "rnow+10"
+step = 10
+req_start = "rnow-10"
+req_stop = "rnow+10"
+values = [1.0, nan]
+
+[[test.render_checks.result]]
+name = "test;env=dev"
+path = "seriesByTag('name=test')"
+consolidation = "avg"
+start = "rnow-10"
+stop = "rnow+10"
+step = 10
+req_start = "rnow-10"
+req_stop = "rnow+10"
+values = [1.0, nan]
+
+[[test.render_checks.result]]
+name = "test;env=stage"
+path = "seriesByTag('name=test')"
+consolidation = "avg"
+start = "rnow-10"
+stop = "rnow+10"
+step = 10
+req_start = "rnow-10"
+req_stop = "rnow+10"
+values = [1.0, nan]
+
+[[test.render_checks]]
+from = "rnow-10"
+until = "rnow+1"
+timeout = "1h"
+targets = [ 
+    "seriesByTag('env=dev')", 
+]
+
+[[test.render_checks.result]]
+name = "test;env=dev"
+path = "seriesByTag('env=dev')"
+consolidation = "avg"
+start = "rnow-10"
+stop = "rnow+10"
+step = 10
+req_start = "rnow-10"
+req_stop = "rnow+10"
+values = [1.0, nan]
+
+# due to 'use-carbon-behaviour = true'
+[[test.render_checks]]
+from = "rnow-10"
+until = "rnow+1"
+timeout = "1h"
+targets = [ 
+    "seriesByTag('env=')", 
+]
+error_regexp = "^403: seriesByTag argument has too much wildcard and regex terms"
+
+
+[[test.render_checks]]
+from = "rnow-10"
+until = "rnow+1"
+timeout = "1h"
+targets = [ 
+    "seriesByTag('env!=prod')", 
+]
+error_regexp = "^403: seriesByTag argument has too much wildcard and regex terms"
+
+[[test.render_checks]]
+from = "rnow-10"
+until = "rnow+1"
+timeout = "1h"
+targets = [ 
+    "seriesByTag('env!=')", 
+]
+error_regexp = "^403: seriesByTag argument has too much wildcard and regex terms"
+
+[[test.render_checks]]
+from = "rnow-10"
+until = "rnow+1"
+timeout = "1h"
+targets = [ 
+    "seriesByTag('env=~')", 
+]
+error_regexp = "^403: seriesByTag argument has too much wildcard and regex terms"
+
+[[test.render_checks]]
+from = "rnow-10"
+until = "rnow+1"
+timeout = "1h"
+targets = [ 
+    "seriesByTag('env=~pr')", 
+]
+error_regexp = "^403: seriesByTag argument has too much wildcard and regex terms"
+
+[[test.render_checks]]
+from = "rnow-10"
+until = "rnow+1"
+timeout = "1h"
+targets = [ 
+    "seriesByTag('env!=~')", 
+]
+error_regexp = "^403: seriesByTag argument has too much wildcard and regex terms"
+
+[[test.render_checks]]
+from = "rnow-10"
+until = "rnow+1"
+timeout = "1h"
+targets = [ 
+    "seriesByTag('env!=~pr')", 
+]
+error_regexp = "^403: seriesByTag argument has too much wildcard and regex terms"


### PR DESCRIPTION
With use-carbon-behaviour enabled terms like `'tag='` will match all metrics that don't have that tag. Queries like that might be quite expensive. This PR makes these terms count as "wildcard" terms so that they don't avoid `tags-min-in-query` config option.