### PR TITLE
fix(index): ignore wildcard-min-distance when amount of nodes is 1

### DIFF
--- a/finder/index.go
+++ b/finder/index.go
@@ -162,7 +162,12 @@ func (idx *IndexFinder) validatePlainQuery(query string, wildcardMinDistance int
 
 	var maxDist = where.MaxWildcardDistance(query)
 
-	if maxDist != -1 && maxDist < wildcardMinDistance {
+	// If the amount of nodes in a plain query is equal to 1,
+	// then make an exception
+	// This allows to check which root nodes exist
+	moreThanOneNode := strings.Count(query, ".") >= 1
+
+	if maxDist != -1 && maxDist < wildcardMinDistance && moreThanOneNode {
 		return errs.NewErrorWithCode("query has wildcards way too early at the start and at the end of it", http.StatusBadRequest)
 	}
 

--- a/tests/wildcard_min_distance/test.toml
+++ b/tests/wildcard_min_distance/test.toml
@@ -190,3 +190,11 @@ targets = [
     "*.*", 
 ]
 error_regexp = "^400: query has wildcards way too early at the start and at the end of it"
+
+[[test.render_checks]]
+from = "rnow-10"
+until = "rnow+1"
+timeout = "1h"
+targets = [ 
+    "*", 
+]


### PR DESCRIPTION
If the amount of nodes in a plain query is equal to 1, then bypass the limitation set by wildcard-min-distance.
This allows to check which root nodes exist.
