### PR TITLE
feat: query split

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -222,8 +222,8 @@ type ClickHouse struct {
 	TagsLimiter           limiter.ServerLimiter `toml:"-"                        json:"-"`
 
 	WildcardMinDistance   int  `toml:"wildcard-min-distance" json:"wildcard-min-distance" comment:"If a wildcard appears both at the start and the end of a plain query at a distance (in terms of nodes) less than wildcard-min-distance, then it will be discarded. This parameter can be used to discard expensive queries."`
-	TrySplitQuery         bool `toml:"try-split-query" json:"try-split-query" comment:"Plain queries like '{first,second}.custom.metric.*' are also a subject to wildcard-min-distance restriction. But can be split into 2 queries: 'first.custom.metric.*', 'second.custom.metric.*'."`
-	MaxNodeToSplitIndex   int  `toml:"max-node-to-split-index" json:"max-node-to-split-index" comment:"Used only if try-split-query is true. Query that contains list will be split if its (list) node index is less or equal to max-node-to-split-index. By default is 0"`
+	TrySplitQuery         bool `toml:"try-split-query" json:"try-split-query" comment:"Plain queries like '{first,second}.custom.metric.*' are also a subject to wildcard-min-distance restriction. But can be split into 2 queries: 'first.custom.metric.*', 'second.custom.metric.*'. Note that: only one list will be split; if there are wildcard in query before (after) list then reverse (direct) notation will be preferred; if there are wildcards before and after list, then query will not be split"`
+	MaxNodeToSplitIndex   int  `toml:"max-node-to-split-index" json:"max-node-to-split-index" comment:"Used only if try-split-query is true. Query that contains list will be split if its (list) node index is less or equal to max-node-to-split-index. By default is 0. It is recommended to have this value set to 2 or 3 and increase it very carefully, because 3 or 4 plain nodes without wildcards have good selectivity"`
 	TagsMinInQuery        int  `toml:"tags-min-in-query" json:"tags-min-in-query" comment:"Minimum tags in seriesByTag query"`
 	TagsMinInAutocomplete int  `toml:"tags-min-in-autocomplete" json:"tags-min-in-autocomplete" comment:"Minimum tags in autocomplete query"`
 

--- a/config/config.go
+++ b/config/config.go
@@ -221,9 +221,10 @@ type ClickHouse struct {
 	TagsAdaptiveQueries   int                   `toml:"tags-adaptive-queries" json:"tags-adaptive-queries" comment:"Tags adaptive queries (based on load average) for increase/decrease concurrent queries"`
 	TagsLimiter           limiter.ServerLimiter `toml:"-"                        json:"-"`
 
-	WildcardMinDistance   int `toml:"wildcard-min-distance" json:"wildcard-min-distance" comment:"If a wildcard appears both at the start and the end of a plain query at a distance (in terms of nodes) less than wildcard-min-distance, then it will be discarded. This parameter can be used to discard expensive queries."`
-	TagsMinInQuery        int `toml:"tags-min-in-query" json:"tags-min-in-query" comment:"Minimum tags in seriesByTag query"`
-	TagsMinInAutocomplete int `toml:"tags-min-in-autocomplete" json:"tags-min-in-autocomplete" comment:"Minimum tags in autocomplete query"`
+	WildcardMinDistance   int  `toml:"wildcard-min-distance" json:"wildcard-min-distance" comment:"If a wildcard appears both at the start and the end of a plain query at a distance (in terms of nodes) less than wildcard-min-distance, then it will be discarded. This parameter can be used to discard expensive queries."`
+	TrySplitQuery         bool `toml:"try-split-query" json:"try-split-query" comment:"Plain queries like '{first,second}.custom.metric.*' are also a subject to wildcard-min-distance restriction. But can be split into 2 queries: 'first.custom.metric.*', 'second.custom.metric.*'."`
+	TagsMinInQuery        int  `toml:"tags-min-in-query" json:"tags-min-in-query" comment:"Minimum tags in seriesByTag query"`
+	TagsMinInAutocomplete int  `toml:"tags-min-in-autocomplete" json:"tags-min-in-autocomplete" comment:"Minimum tags in autocomplete query"`
 
 	UserLimits           map[string]UserLimits `toml:"user-limits"              json:"user-limits"              comment:"customized query limiter for some users"                                                                                        commented:"true"`
 	DateFormat           string                `toml:"date-format"              json:"date-format"              comment:"Date format (default, utc, both)"`

--- a/config/config.go
+++ b/config/config.go
@@ -223,6 +223,7 @@ type ClickHouse struct {
 
 	WildcardMinDistance   int  `toml:"wildcard-min-distance" json:"wildcard-min-distance" comment:"If a wildcard appears both at the start and the end of a plain query at a distance (in terms of nodes) less than wildcard-min-distance, then it will be discarded. This parameter can be used to discard expensive queries."`
 	TrySplitQuery         bool `toml:"try-split-query" json:"try-split-query" comment:"Plain queries like '{first,second}.custom.metric.*' are also a subject to wildcard-min-distance restriction. But can be split into 2 queries: 'first.custom.metric.*', 'second.custom.metric.*'."`
+	MaxNodeToSplitIndex   int  `toml:"max-node-to-split-index" json:"max-node-to-split-index" comment:"Used only if try-split-query is true. Query that contains list will be split if its (list) node index is less or equal to max-node-to-split-index."`
 	TagsMinInQuery        int  `toml:"tags-min-in-query" json:"tags-min-in-query" comment:"Minimum tags in seriesByTag query"`
 	TagsMinInAutocomplete int  `toml:"tags-min-in-autocomplete" json:"tags-min-in-autocomplete" comment:"Minimum tags in autocomplete query"`
 
@@ -402,6 +403,7 @@ func New() *Config {
 			InternalAggregation:  true,
 			FindLimiter:          limiter.NoopLimiter{},
 			TagsLimiter:          limiter.NoopLimiter{},
+			MaxNodeToSplitIndex:  -1,
 		},
 		Tags: Tags{
 			Threads:     1,

--- a/config/config.go
+++ b/config/config.go
@@ -223,7 +223,7 @@ type ClickHouse struct {
 
 	WildcardMinDistance   int  `toml:"wildcard-min-distance" json:"wildcard-min-distance" comment:"If a wildcard appears both at the start and the end of a plain query at a distance (in terms of nodes) less than wildcard-min-distance, then it will be discarded. This parameter can be used to discard expensive queries."`
 	TrySplitQuery         bool `toml:"try-split-query" json:"try-split-query" comment:"Plain queries like '{first,second}.custom.metric.*' are also a subject to wildcard-min-distance restriction. But can be split into 2 queries: 'first.custom.metric.*', 'second.custom.metric.*'."`
-	MaxNodeToSplitIndex   int  `toml:"max-node-to-split-index" json:"max-node-to-split-index" comment:"Used only if try-split-query is true. Query that contains list will be split if its (list) node index is less or equal to max-node-to-split-index."`
+	MaxNodeToSplitIndex   int  `toml:"max-node-to-split-index" json:"max-node-to-split-index" comment:"Used only if try-split-query is true. Query that contains list will be split if its (list) node index is less or equal to max-node-to-split-index. By default is 0"`
 	TagsMinInQuery        int  `toml:"tags-min-in-query" json:"tags-min-in-query" comment:"Minimum tags in seriesByTag query"`
 	TagsMinInAutocomplete int  `toml:"tags-min-in-autocomplete" json:"tags-min-in-autocomplete" comment:"Minimum tags in autocomplete query"`
 
@@ -403,7 +403,6 @@ func New() *Config {
 			InternalAggregation:  true,
 			FindLimiter:          limiter.NoopLimiter{},
 			TagsLimiter:          limiter.NoopLimiter{},
-			MaxNodeToSplitIndex:  -1,
 		},
 		Tags: Tags{
 			Threads:     1,

--- a/doc/config.md
+++ b/doc/config.md
@@ -315,8 +315,8 @@ Only one tag used as filter for index field Tag1, see graphite_tagged table [str
  wildcard-min-distance = 0
  # Plain queries like '{first,second}.custom.metric.*' are also a subject to wildcard-min-distance restriction. But can be split into 2 queries: 'first.custom.metric.*', 'second.custom.metric.*'.
  try-split-query = false
- # Used only if try-split-query is true. Query that contains list will be split if its node index is less or equal to max-node-to-split-index.
- max-node-to-split-index = -1
+ # Used only if try-split-query is true. Query that contains list will be split if its (list) node index is less or equal to max-node-to-split-index. By default is 0
+ max-node-to-split-index = 0
  # Minimum tags in seriesByTag query
  tags-min-in-query = 0
  # Minimum tags in autocomplete query

--- a/doc/config.md
+++ b/doc/config.md
@@ -315,6 +315,8 @@ Only one tag used as filter for index field Tag1, see graphite_tagged table [str
  wildcard-min-distance = 0
  # Plain queries like '{first,second}.custom.metric.*' are also a subject to wildcard-min-distance restriction. But can be split into 2 queries: 'first.custom.metric.*', 'second.custom.metric.*'.
  try-split-query = false
+ # Used only if try-split-query is true. Query that contains list will be split if its node index is less or equal to max-node-to-split-index.
+ max-node-to-split-index = -1
  # Minimum tags in seriesByTag query
  tags-min-in-query = 0
  # Minimum tags in autocomplete query

--- a/doc/config.md
+++ b/doc/config.md
@@ -313,9 +313,9 @@ Only one tag used as filter for index field Tag1, see graphite_tagged table [str
  tags-adaptive-queries = 0
  # If a wildcard appears both at the start and the end of a plain query at a distance (in terms of nodes) less than wildcard-min-distance, then it will be discarded. This parameter can be used to discard expensive queries.
  wildcard-min-distance = 0
- # Plain queries like '{first,second}.custom.metric.*' are also a subject to wildcard-min-distance restriction. But can be split into 2 queries: 'first.custom.metric.*', 'second.custom.metric.*'.
+ # Plain queries like '{first,second}.custom.metric.*' are also a subject to wildcard-min-distance restriction. But can be split into 2 queries: 'first.custom.metric.*', 'second.custom.metric.*'. Note that: only one list will be split; if there are wildcard in query before (after) list then reverse (direct) notation will be preferred; if there are wildcards before and after list, then query will not be split
  try-split-query = false
- # Used only if try-split-query is true. Query that contains list will be split if its (list) node index is less or equal to max-node-to-split-index. By default is 0
+ # Used only if try-split-query is true. Query that contains list will be split if its (list) node index is less or equal to max-node-to-split-index. By default is 0. It is recommended to have this value set to 2 or 3 and increase it very carefully, because 3 or 4 plain nodes without wildcards have good selectivity
  max-node-to-split-index = 0
  # Minimum tags in seriesByTag query
  tags-min-in-query = 0

--- a/doc/config.md
+++ b/doc/config.md
@@ -313,6 +313,8 @@ Only one tag used as filter for index field Tag1, see graphite_tagged table [str
  tags-adaptive-queries = 0
  # If a wildcard appears both at the start and the end of a plain query at a distance (in terms of nodes) less than wildcard-min-distance, then it will be discarded. This parameter can be used to discard expensive queries.
  wildcard-min-distance = 0
+ # Plain queries like '{first,second}.custom.metric.*' are also a subject to wildcard-min-distance restriction. But can be split into 2 queries: 'first.custom.metric.*', 'second.custom.metric.*'.
+ try-split-query = false
  # Minimum tags in seriesByTag query
  tags-min-in-query = 0
  # Minimum tags in autocomplete query

--- a/finder/finder.go
+++ b/finder/finder.go
@@ -70,6 +70,7 @@ func newPlainFinder(ctx context.Context, config *config.Config, query string, fr
 		if config.ClickHouse.TrySplitQuery {
 			f = WrapSplitIndex(
 				f,
+				config.ClickHouse.WildcardMinDistance,
 				config.ClickHouse.URL,
 				config.ClickHouse.IndexTable,
 				config.ClickHouse.IndexUseDaily,

--- a/finder/finder.go
+++ b/finder/finder.go
@@ -66,6 +66,10 @@ func newPlainFinder(ctx context.Context, config *config.Config, query string, fr
 			opts,
 			useCache,
 		)
+
+		if config.ClickHouse.TrySplitQuery {
+			f = WrapSplitIndex(f, opts, useCache)
+		}
 	} else {
 		if from > 0 && until > 0 && config.ClickHouse.DateTreeTable != "" {
 			f = NewDateFinder(config.ClickHouse.URL, config.ClickHouse.DateTreeTable, config.ClickHouse.DateTreeTableVersion, opts)
@@ -76,10 +80,6 @@ func newPlainFinder(ctx context.Context, config *config.Config, query string, fr
 		if config.ClickHouse.ReverseTreeTable != "" {
 			f = WrapReverse(f, config.ClickHouse.URL, config.ClickHouse.ReverseTreeTable, opts)
 		}
-	}
-
-	if config.ClickHouse.TrySplitQuery {
-		f = WrapSplit(f, useCache)
 	}
 
 	if config.ClickHouse.TagTable != "" {

--- a/finder/finder.go
+++ b/finder/finder.go
@@ -78,6 +78,10 @@ func newPlainFinder(ctx context.Context, config *config.Config, query string, fr
 		}
 	}
 
+	if config.ClickHouse.TrySplitQuery {
+		f = WrapSplit(f, useCache)
+	}
+
 	if config.ClickHouse.TagTable != "" {
 		f = WrapTag(f, config.ClickHouse.URL, config.ClickHouse.TagTable, opts)
 	}

--- a/finder/finder.go
+++ b/finder/finder.go
@@ -68,7 +68,16 @@ func newPlainFinder(ctx context.Context, config *config.Config, query string, fr
 		)
 
 		if config.ClickHouse.TrySplitQuery {
-			f = WrapSplitIndex(f, opts, useCache)
+			f = WrapSplitIndex(
+				f,
+				config.ClickHouse.URL,
+				config.ClickHouse.IndexTable,
+				config.ClickHouse.IndexUseDaily,
+				config.ClickHouse.IndexReverse,
+				config.ClickHouse.IndexReverses,
+				opts,
+				useCache,
+			)
 		}
 	} else {
 		if from > 0 && until > 0 && config.ClickHouse.DateTreeTable != "" {

--- a/finder/index.go
+++ b/finder/index.go
@@ -249,31 +249,6 @@ func (idx *IndexFinder) bodySplit() {
 	if setDirect {
 		idx.reverse = queryDirect
 	}
-
-	//if len(idx.body) == 0 {
-	//	return
-	//}
-	//
-	//idx.rows = bytes.Split(bytes.TrimSuffix(idx.body, []byte{'\n'}), []byte{'\n'})
-	//
-	//if idx.useReverse("") {
-	//	// rotate names for reduce
-	//	var buf bytes.Buffer
-	//	if idx.useCache {
-	//		buf.Grow(len(idx.body))
-	//	}
-	//	for i := 0; i < len(idx.rows); i++ {
-	//		idx.rows[i] = ReverseBytes(idx.rows[i])
-	//		if idx.useCache {
-	//			buf.Write(idx.rows[i])
-	//			buf.WriteByte('\n')
-	//		}
-	//	}
-	//	if idx.useCache {
-	//		idx.body = buf.Bytes()
-	//		idx.reverse = queryDirect
-	//	}
-	//}
 }
 
 func makeList(rows [][]byte, onlySeries bool) [][]byte {

--- a/finder/index.go
+++ b/finder/index.go
@@ -119,20 +119,13 @@ func (idx *IndexFinder) useReverse(query string) bool {
 	return idx.useReverse(query)
 }
 
-func (idx *IndexFinder) whereFilter(query string, from int64, until int64) *where.Where {
-	reverse := idx.useReverse(query)
-	if reverse {
-		query = ReverseString(query)
-	}
+func useDaily(dailyEnabled bool, from, until int64) bool {
+	return dailyEnabled && from > 0 && until > 0
+}
 
-	if idx.dailyEnabled && from > 0 && until > 0 {
-		idx.useDaily = true
-	} else {
-		idx.useDaily = false
-	}
-
+func calculateIndexLevelOffset(useDaily, reverse bool) int {
 	var levelOffset int
-	if idx.useDaily {
+	if useDaily {
 		if reverse {
 			levelOffset = ReverseLevelOffset
 		}
@@ -142,8 +135,11 @@ func (idx *IndexFinder) whereFilter(query string, from int64, until int64) *wher
 		levelOffset = TreeLevelOffset
 	}
 
-	w := idx.where(query, levelOffset)
-	if idx.useDaily {
+	return levelOffset
+}
+
+func addDatesToWhere(w *where.Where, useDaily bool, from, until int64) {
+	if useDaily {
 		w.Andf(
 			"Date >='%s' AND Date <= '%s'",
 			date.FromTimestampToDaysFormat(from),
@@ -152,6 +148,20 @@ func (idx *IndexFinder) whereFilter(query string, from int64, until int64) *wher
 	} else {
 		w.And(where.Eq("Date", DefaultTreeDate))
 	}
+}
+
+func (idx *IndexFinder) whereFilter(query string, from int64, until int64) *where.Where {
+	reverse := idx.useReverse(query)
+	if reverse {
+		query = ReverseString(query)
+	}
+
+	idx.useDaily = useDaily(idx.dailyEnabled, from, until)
+
+	levelOffset := calculateIndexLevelOffset(idx.useDaily, reverse)
+
+	w := idx.where(query, levelOffset)
+	addDatesToWhere(w, idx.useDaily, from, until)
 	return w
 }
 
@@ -202,45 +212,86 @@ func (idx *IndexFinder) Abs(v []byte) []byte {
 	return v
 }
 
-func (idx *IndexFinder) bodySplit() {
-	if len(idx.body) == 0 {
-		return
+func splitIndexBody(body []byte, useReverse, useCache bool) ([]byte, [][]byte, bool) {
+	if len(body) == 0 {
+		return body, [][]byte{}, false
 	}
 
-	idx.rows = bytes.Split(bytes.TrimSuffix(idx.body, []byte{'\n'}), []byte{'\n'})
+	rows := bytes.Split(bytes.TrimSuffix(body, []byte{'\n'}), []byte{'\n'})
+	setDirect := false
 
-	if idx.useReverse("") {
-		// rotate names for reduce
+	if useReverse {
 		var buf bytes.Buffer
-		if idx.useCache {
-			buf.Grow(len(idx.body))
+		if useCache {
+			buf.Grow(len(body))
 		}
-		for i := 0; i < len(idx.rows); i++ {
-			idx.rows[i] = ReverseBytes(idx.rows[i])
-			if idx.useCache {
-				buf.Write(idx.rows[i])
+
+		for i := range rows {
+			rows[i] = ReverseBytes(rows[i])
+			if useCache {
+				buf.Write(rows[i])
 				buf.WriteByte('\n')
 			}
 		}
-		if idx.useCache {
-			idx.body = buf.Bytes()
-			idx.reverse = queryDirect
+
+		if useCache {
+			body = buf.Bytes()
+			setDirect = true
 		}
 	}
+
+	return body, rows, setDirect
 }
 
-func (idx *IndexFinder) makeList(onlySeries bool) [][]byte {
-	if len(idx.rows) == 0 {
+func (idx *IndexFinder) bodySplit() {
+	setDirect := false
+	idx.body, idx.rows, setDirect = splitIndexBody(idx.body, idx.useReverse(""), idx.useCache)
+	if setDirect {
+		idx.reverse = queryDirect
+	}
+
+	//if len(idx.body) == 0 {
+	//	return
+	//}
+	//
+	//idx.rows = bytes.Split(bytes.TrimSuffix(idx.body, []byte{'\n'}), []byte{'\n'})
+	//
+	//if idx.useReverse("") {
+	//	// rotate names for reduce
+	//	var buf bytes.Buffer
+	//	if idx.useCache {
+	//		buf.Grow(len(idx.body))
+	//	}
+	//	for i := 0; i < len(idx.rows); i++ {
+	//		idx.rows[i] = ReverseBytes(idx.rows[i])
+	//		if idx.useCache {
+	//			buf.Write(idx.rows[i])
+	//			buf.WriteByte('\n')
+	//		}
+	//	}
+	//	if idx.useCache {
+	//		idx.body = buf.Bytes()
+	//		idx.reverse = queryDirect
+	//	}
+	//}
+}
+
+func makeList(rows [][]byte, onlySeries bool) [][]byte {
+	if len(rows) == 0 {
 		return [][]byte{}
 	}
 
-	rows := make([][]byte, len(idx.rows))
+	resRows := make([][]byte, len(rows))
 
-	for i := 0; i < len(idx.rows); i++ {
-		rows[i] = idx.rows[i]
+	for i := 0; i < len(rows); i++ {
+		resRows[i] = rows[i]
 	}
 
-	return rows
+	return resRows
+}
+
+func (idx *IndexFinder) makeList(onlySeries bool) [][]byte {
+	return makeList(idx.rows, onlySeries)
 }
 
 func (idx *IndexFinder) List() [][]byte {

--- a/finder/index.go
+++ b/finder/index.go
@@ -155,7 +155,7 @@ func (idx *IndexFinder) whereFilter(query string, from int64, until int64) *wher
 	return w
 }
 
-func (idx *IndexFinder) validatePlainQuery(query string, wildcardMinDistance int) error {
+func validatePlainQuery(query string, wildcardMinDistance int) error {
 	if where.HasUnmatchedBrackets(query) {
 		return errs.NewErrorWithCode("query has unmatched brackets", http.StatusBadRequest)
 	}
@@ -175,7 +175,7 @@ func (idx *IndexFinder) validatePlainQuery(query string, wildcardMinDistance int
 }
 
 func (idx *IndexFinder) Execute(ctx context.Context, config *config.Config, query string, from int64, until int64, stat *FinderStat) (err error) {
-	err = idx.validatePlainQuery(query, config.ClickHouse.WildcardMinDistance)
+	err = validatePlainQuery(query, config.ClickHouse.WildcardMinDistance)
 	if err != nil {
 		return err
 	}

--- a/finder/split.go
+++ b/finder/split.go
@@ -100,11 +100,24 @@ func splitQuery(query string) ([]string, error) {
 	directNodeCount := strings.Count(query[:firstOpenBracketsIndex], ".")
 	directWildcardIndex := where.IndexWildcard(query[:firstOpenBracketsIndex])
 	choicesInLeftMost := strings.Count(query[firstOpenBracketsIndex:firstClosingBracketIndex], ",")
+	//fmt.Printf("\ndirect:\n\tnodeCount = %v\n\twildcardIndex = %v\n\tchoices = %v\n",
+	//	directNodeCount,
+	//	directWildcardIndex,
+	//	choicesInLeftMost)
 
 	lastClosingBracketIndex := strings.LastIndex(query, "}")
 	reverseNodeCount := strings.Count(query[lastClosingBracketIndex:], ".")
-	reversWildcardIndex := where.IndexLastWildcard(query[lastClosingBracketIndex:])
+	var reversWildcardIndex int
+	if lastClosingBracketIndex == len(query)-1 {
+		reversWildcardIndex = -1
+	} else {
+		reversWildcardIndex = where.IndexLastWildcard(query[lastClosingBracketIndex+1:])
+	}
 	choicesInRightMost := strings.Count(query[lastOpenBracketIndex:lastClosingBracketIndex], ",")
+	//fmt.Printf("\nreverse:\n\tnodeCount = %v\n\twildcardIndex = %v\n\tchoices = %v\n",
+	//	reverseNodeCount,
+	//	reversWildcardIndex,
+	//	choicesInRightMost)
 
 	useDirect := true
 	if directWildcardIndex >= 0 && reversWildcardIndex < 0 {

--- a/finder/split.go
+++ b/finder/split.go
@@ -66,6 +66,8 @@ func WrapSplitIndex(
 	}
 }
 
+// Execute will try to split query if it contains list in it. If query can't be split wrapped Finder will be used.
+// Use List, Series or Bytes after calling Execute to get data.
 func (splitFinder *SplitIndexFinder) Execute(
 	ctx context.Context,
 	config *config.Config,
@@ -274,6 +276,8 @@ func (splitFinder *SplitIndexFinder) whereFilter(queries []string, from, until i
 	return aggregatedWhere, nil
 }
 
+// List returns clickhouse response split by delimiter.
+// If there was no split, wrapped.List will be used.
 func (splitFinder *SplitIndexFinder) List() [][]byte {
 	if splitFinder.useWrapped {
 		return splitFinder.wrapped.List()
@@ -282,6 +286,7 @@ func (splitFinder *SplitIndexFinder) List() [][]byte {
 	return makeList(splitFinder.rows, false)
 }
 
+// Series same as List. If there was no split, wrapped.Series will be used.
 func (splitFinder *SplitIndexFinder) Series() [][]byte {
 	if splitFinder.useWrapped {
 		return splitFinder.wrapped.Series()
@@ -290,6 +295,8 @@ func (splitFinder *SplitIndexFinder) Series() [][]byte {
 	return makeList(splitFinder.rows, true)
 }
 
+// Abs for this implementation returns given v.
+// If there was no split, wrapped.Abs will be used.
 func (splitFinder *SplitIndexFinder) Abs(v []byte) []byte {
 	if splitFinder.useWrapped {
 		return splitFinder.wrapped.Abs(v)
@@ -298,6 +305,8 @@ func (splitFinder *SplitIndexFinder) Abs(v []byte) []byte {
 	return v
 }
 
+// Bytes returns clickhouse response bytes.
+// If there was no split, wrapped.Bytes will be used.
 func (splitFinder *SplitIndexFinder) Bytes() ([]byte, error) {
 	if splitFinder.useWrapped {
 		return splitFinder.wrapped.Bytes()

--- a/finder/split.go
+++ b/finder/split.go
@@ -2,42 +2,37 @@ package finder
 
 import (
 	"context"
+	"net/http"
 	"strings"
-	"sync"
 
 	"github.com/lomik/graphite-clickhouse/config"
+	"github.com/lomik/graphite-clickhouse/helper/clickhouse"
+	"github.com/lomik/graphite-clickhouse/helper/errs"
 	"github.com/lomik/graphite-clickhouse/pkg/where"
 )
 
-type singleFinderInfo struct {
-	err  error
-	f    Finder
-	stat FinderStat
-}
-
-// SplitPlainQueryFinder will try to split queries like {first,second}.some.metric into n queries (n - number of cases inside {}).
-// No matter if '{}' in first node or not.
-type SplitPlainQueryFinder struct {
-	// useCache flag for internal finders.
-	useCache bool
+// SplitIndexFinder will try to split queries like {first,second}.some.metric into n queries (n - number of cases inside {}).
+// No matter if '{}' in first node or not. Only one {} will be split.
+type SplitIndexFinder struct {
 	// wrapped finder will be called if we can't split query.
 	wrapped Finder
 	// useWrapped indicated if we should use wrapped Finder.
 	useWrapped bool
-	// wildcardFinders will be used for queries (got after split) which have wildcard.
-	wildcardFinders []singleFinderInfo
+	opts       clickhouse.Options
+	useCache   bool
 }
 
-// WrapSplit wraps given finder with SplitPlainQueryFinder logic.
-func WrapSplit(f Finder, useCache bool) *SplitPlainQueryFinder {
-	return &SplitPlainQueryFinder{
-		useCache:   useCache,
+// WrapSplitIndex wraps given finder with SplitIndexFinder logic.
+func WrapSplitIndex(f Finder, opts clickhouse.Options, useCache bool) *SplitIndexFinder {
+	return &SplitIndexFinder{
 		wrapped:    f,
 		useWrapped: false,
+		opts:       opts,
+		useCache:   useCache,
 	}
 }
 
-func (splitFinder *SplitPlainQueryFinder) Execute(
+func (splitFinder *SplitIndexFinder) Execute(
 	ctx context.Context,
 	config *config.Config,
 	query string,
@@ -45,6 +40,10 @@ func (splitFinder *SplitPlainQueryFinder) Execute(
 	until int64,
 	stat *FinderStat,
 ) error {
+	if where.HasUnmatchedBrackets(query) {
+		return errs.NewErrorWithCode("query has unmatched brackets", http.StatusBadRequest)
+	}
+
 	idx := strings.IndexAny(query, "{}")
 	if idx == -1 {
 		splitFinder.useWrapped = true
@@ -56,40 +55,94 @@ func (splitFinder *SplitPlainQueryFinder) Execute(
 		return err
 	}
 
-	queriesWithWildcards := make([]string, 0)
-	queriesNoWildcards := make([]string, 0)
+	aggregatedWhere := where.New()
 	for _, q := range splitQueries {
-		if where.HasWildcard(q) {
-			queriesWithWildcards = append(queriesWithWildcards, q)
-		} else {
-			queriesNoWildcards = append(queriesNoWildcards, q)
+		err = validatePlainQuery(q, config.ClickHouse.WildcardMinDistance)
+		if err != nil {
+			return err
 		}
+
+		indexFinder := NewIndex(
+			config.ClickHouse.URL,
+			config.ClickHouse.IndexTable,
+			config.ClickHouse.IndexUseDaily,
+			config.ClickHouse.IndexReverse,
+			config.ClickHouse.IndexReverses,
+			splitFinder.opts,
+			splitFinder.useCache,
+		).(*IndexFinder)
+
+		aggregatedWhere.Or(indexFinder.whereFilter(q, from, until).String())
 	}
 
-	splitFinder.prepareWildcardFinders(ctx, config, query, from, until, len(queriesWithWildcards))
-
-	wg := sync.WaitGroup{}
-	wg.Add(len(splitFinder.wildcardFinders))
-	for i := range splitFinder.wildcardFinders {
-		go splitFinder.executeSingleFinder(
-			&wg,
-			&splitFinder.wildcardFinders[i],
-			ctx,
-			config,
-			queriesWithWildcards[i],
-			from,
-			until,
-		)
-	}
-
-	// TODO: execute non-wildcards queries in single SQL-query with multiple values in `WHERE Path IN (...)` condition.
+	// TODO: think about max_query_size
 
 	return nil
 }
 
 func splitQuery(query string) ([]string, error) {
-	splitQueries := make([]string, 0)
-	err := where.GlobExpandSimple(query, "", &splitQueries)
+	splitQueries := make([]string, 0, 1)
+
+	firstClosingBracketIndex := strings.Index(query, "}")
+	lastOpenBracketIndex := strings.LastIndex(query, "{")
+
+	if lastOpenBracketIndex < firstClosingBracketIndex {
+		// we have only one bracket in query
+		err := where.GlobExpandSimple(query, "", &splitQueries)
+		if err != nil {
+			return nil, err
+		}
+
+		return splitQueries, nil
+	}
+
+	firstOpenBracketsIndex := strings.Index(query, "{")
+	directNodeCount := strings.Count(query[:firstOpenBracketsIndex], ".")
+	directWildcardIndex := where.IndexWildcard(query[:firstOpenBracketsIndex])
+	choicesInLeftMost := strings.Count(query[firstOpenBracketsIndex:firstClosingBracketIndex], ",")
+
+	lastClosingBracketIndex := strings.LastIndex(query, "}")
+	reverseNodeCount := strings.Count(query[lastClosingBracketIndex:], ".")
+	reversWildcardIndex := where.IndexLastWildcard(query[lastClosingBracketIndex:])
+	choicesInRightMost := strings.Count(query[lastOpenBracketIndex:lastClosingBracketIndex], ",")
+
+	useDirect := true
+	if directWildcardIndex >= 0 && reversWildcardIndex < 0 {
+		useDirect = false
+	} else if directWildcardIndex < 0 && reversWildcardIndex >= 0 {
+		useDirect = true
+	} else if directWildcardIndex >= 0 && reversWildcardIndex >= 0 {
+		if choicesInLeftMost >= choicesInRightMost {
+			useDirect = true
+		} else {
+			useDirect = false
+		}
+	} else {
+		if directNodeCount > reverseNodeCount {
+			useDirect = true
+		} else if reverseNodeCount > directNodeCount {
+			useDirect = false
+		} else {
+			if choicesInLeftMost >= choicesInRightMost {
+				useDirect = true
+			} else {
+				useDirect = false
+			}
+		}
+	}
+
+	var prefix, suffix, queryPart string
+	if useDirect {
+		prefix = ""
+		queryPart = query[:firstClosingBracketIndex+1]
+		suffix = query[firstClosingBracketIndex+1:]
+	} else {
+		prefix = query[:lastOpenBracketIndex]
+		queryPart = query[lastOpenBracketIndex:]
+		suffix = ""
+	}
+
+	splitQueries, err := splitPartOfQuery(prefix, queryPart, suffix)
 	if err != nil {
 		return nil, err
 	}
@@ -97,45 +150,22 @@ func splitQuery(query string) ([]string, error) {
 	return splitQueries, nil
 }
 
-func (splitFinder *SplitPlainQueryFinder) prepareWildcardFinders(
-	ctx context.Context,
-	config *config.Config,
-	query string,
-	from int64,
-	until int64,
-	count int,
-) {
-	if count == 0 {
-		return
+func splitPartOfQuery(prefix, queryPart, suffix string) ([]string, error) {
+	splitQueries := make([]string, 0)
+
+	err := where.GlobExpandSimple(queryPart, "", &splitQueries)
+	if err != nil {
+		return nil, err
 	}
 
-	splitFinder.wildcardFinders = make([]singleFinderInfo, 0, count)
-	for i := 0; i < count; i++ {
-		splitFinder.wildcardFinders = append(
-			splitFinder.wildcardFinders,
-			singleFinderInfo{
-				err: nil,
-				f:   newPlainFinder(ctx, config, query, from, until, splitFinder.useCache),
-			},
-		)
+	for i := range splitQueries {
+		splitQueries[i] = prefix + splitQueries[i] + suffix
 	}
+
+	return splitQueries, nil
 }
 
-func (splitFinder *SplitPlainQueryFinder) executeSingleFinder(
-	wg *sync.WaitGroup,
-	finderInfo *singleFinderInfo,
-	ctx context.Context,
-	config *config.Config,
-	query string,
-	from int64,
-	until int64,
-) {
-	defer wg.Done()
-
-	finderInfo.err = finderInfo.f.Execute(ctx, config, query, from, until, &finderInfo.stat)
-}
-
-func (splitFinder *SplitPlainQueryFinder) List() [][]byte {
+func (splitFinder *SplitIndexFinder) List() [][]byte {
 	if splitFinder.useWrapped {
 		return splitFinder.wrapped.List()
 	}
@@ -143,7 +173,7 @@ func (splitFinder *SplitPlainQueryFinder) List() [][]byte {
 	return EmptyList
 }
 
-func (splitFinder *SplitPlainQueryFinder) Series() [][]byte {
+func (splitFinder *SplitIndexFinder) Series() [][]byte {
 	if splitFinder.useWrapped {
 		return splitFinder.wrapped.Series()
 	}
@@ -151,7 +181,7 @@ func (splitFinder *SplitPlainQueryFinder) Series() [][]byte {
 	return nil
 }
 
-func (splitFinder *SplitPlainQueryFinder) Abs(v []byte) []byte {
+func (splitFinder *SplitIndexFinder) Abs(v []byte) []byte {
 	if splitFinder.useWrapped {
 		return splitFinder.wrapped.Abs(v)
 	}
@@ -159,7 +189,7 @@ func (splitFinder *SplitPlainQueryFinder) Abs(v []byte) []byte {
 	return nil
 }
 
-func (splitFinder *SplitPlainQueryFinder) Bytes() ([]byte, error) {
+func (splitFinder *SplitIndexFinder) Bytes() ([]byte, error) {
 	if splitFinder.useWrapped {
 		return splitFinder.wrapped.Bytes()
 	}

--- a/finder/split.go
+++ b/finder/split.go
@@ -1,0 +1,168 @@
+package finder
+
+import (
+	"context"
+	"strings"
+	"sync"
+
+	"github.com/lomik/graphite-clickhouse/config"
+	"github.com/lomik/graphite-clickhouse/pkg/where"
+)
+
+type singleFinderInfo struct {
+	err  error
+	f    Finder
+	stat FinderStat
+}
+
+// SplitPlainQueryFinder will try to split queries like {first,second}.some.metric into n queries (n - number of cases inside {}).
+// No matter if '{}' in first node or not.
+type SplitPlainQueryFinder struct {
+	// useCache flag for internal finders.
+	useCache bool
+	// wrapped finder will be called if we can't split query.
+	wrapped Finder
+	// useWrapped indicated if we should use wrapped Finder.
+	useWrapped bool
+	// wildcardFinders will be used for queries (got after split) which have wildcard.
+	wildcardFinders []singleFinderInfo
+}
+
+// WrapSplit wraps given finder with SplitPlainQueryFinder logic.
+func WrapSplit(f Finder, useCache bool) *SplitPlainQueryFinder {
+	return &SplitPlainQueryFinder{
+		useCache:   useCache,
+		wrapped:    f,
+		useWrapped: false,
+	}
+}
+
+func (splitFinder *SplitPlainQueryFinder) Execute(
+	ctx context.Context,
+	config *config.Config,
+	query string,
+	from int64,
+	until int64,
+	stat *FinderStat,
+) error {
+	idx := strings.IndexAny(query, "{}")
+	if idx == -1 {
+		splitFinder.useWrapped = true
+		return splitFinder.wrapped.Execute(ctx, config, query, from, until, stat)
+	}
+
+	splitQueries, err := splitQuery(query)
+	if err != nil {
+		return err
+	}
+
+	queriesWithWildcards := make([]string, 0)
+	queriesNoWildcards := make([]string, 0)
+	for _, q := range splitQueries {
+		if where.HasWildcard(q) {
+			queriesWithWildcards = append(queriesWithWildcards, q)
+		} else {
+			queriesNoWildcards = append(queriesNoWildcards, q)
+		}
+	}
+
+	splitFinder.prepareWildcardFinders(ctx, config, query, from, until, len(queriesWithWildcards))
+
+	wg := sync.WaitGroup{}
+	wg.Add(len(splitFinder.wildcardFinders))
+	for i := range splitFinder.wildcardFinders {
+		go splitFinder.executeSingleFinder(
+			&wg,
+			&splitFinder.wildcardFinders[i],
+			ctx,
+			config,
+			queriesWithWildcards[i],
+			from,
+			until,
+		)
+	}
+
+	// TODO: execute non-wildcards queries in single SQL-query with multiple values in `WHERE Path IN (...)` condition.
+
+	return nil
+}
+
+func splitQuery(query string) ([]string, error) {
+	splitQueries := make([]string, 0)
+	err := where.GlobExpandSimple(query, "", &splitQueries)
+	if err != nil {
+		return nil, err
+	}
+
+	return splitQueries, nil
+}
+
+func (splitFinder *SplitPlainQueryFinder) prepareWildcardFinders(
+	ctx context.Context,
+	config *config.Config,
+	query string,
+	from int64,
+	until int64,
+	count int,
+) {
+	if count == 0 {
+		return
+	}
+
+	splitFinder.wildcardFinders = make([]singleFinderInfo, 0, count)
+	for i := 0; i < count; i++ {
+		splitFinder.wildcardFinders = append(
+			splitFinder.wildcardFinders,
+			singleFinderInfo{
+				err: nil,
+				f:   newPlainFinder(ctx, config, query, from, until, splitFinder.useCache),
+			},
+		)
+	}
+}
+
+func (splitFinder *SplitPlainQueryFinder) executeSingleFinder(
+	wg *sync.WaitGroup,
+	finderInfo *singleFinderInfo,
+	ctx context.Context,
+	config *config.Config,
+	query string,
+	from int64,
+	until int64,
+) {
+	defer wg.Done()
+
+	finderInfo.err = finderInfo.f.Execute(ctx, config, query, from, until, &finderInfo.stat)
+}
+
+func (splitFinder *SplitPlainQueryFinder) List() [][]byte {
+	if splitFinder.useWrapped {
+		return splitFinder.wrapped.List()
+	}
+
+	return EmptyList
+}
+
+func (splitFinder *SplitPlainQueryFinder) Series() [][]byte {
+	if splitFinder.useWrapped {
+		return splitFinder.wrapped.Series()
+	}
+
+	return nil
+}
+
+func (splitFinder *SplitPlainQueryFinder) Abs(v []byte) []byte {
+	if splitFinder.useWrapped {
+		return splitFinder.wrapped.Abs(v)
+	}
+
+	return nil
+}
+
+func (splitFinder *SplitPlainQueryFinder) Bytes() ([]byte, error) {
+	if splitFinder.useWrapped {
+		return splitFinder.wrapped.Bytes()
+	}
+
+	return nil, ErrNotImplemented
+}

--- a/finder/split.go
+++ b/finder/split.go
@@ -218,15 +218,10 @@ func (splitFinder *SplitIndexFinder) whereFilter(queries []string, from, until i
 	}
 
 	if queryWithWildcardIdx >= 0 {
-		splitFinder.useReverse = NewIndex(
-			splitFinder.url,
-			splitFinder.table,
-			splitFinder.dailyEnabled,
-			splitFinder.reverse,
-			splitFinder.confReverses,
-			splitFinder.opts,
-			splitFinder.useCache,
-		).(*IndexFinder).useReverse(queries[queryWithWildcardIdx])
+		splitFinder.useReverse = (&IndexFinder{
+			confReverses: splitFinder.confReverses,
+			confReverse:  config.IndexReverse[splitFinder.reverse],
+		}).useReverse(queries[queryWithWildcardIdx])
 	} else {
 		splitFinder.useReverse = false
 	}

--- a/finder/split_test.go
+++ b/finder/split_test.go
@@ -178,6 +178,16 @@ func Test_splitQuery(t *testing.T) {
 			expectedErr: nil,
 			desc:        "not split query",
 		},
+		{
+			givenQuery:               "*.query.{a,b}",
+			givenMaxNodeToSplitIndex: 20,
+			expectedQueries: []string{
+				"*.query.a",
+				"*.query.b",
+			},
+			expectedErr: nil,
+			desc:        "query split if MaxNodeToSplitIndex is greater than nodes amount in query",
+		},
 	}
 
 	for i, singleCase := range cases {

--- a/finder/split_test.go
+++ b/finder/split_test.go
@@ -1,0 +1,104 @@
+package finder
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_splitQuery(t *testing.T) {
+	type testcase struct {
+		givenQuery      string
+		expectedQueries []string
+		expectedErr     error
+		desc            string
+	}
+
+	cases := []testcase{
+		{
+			givenQuery: "{first,second}.some.metric.*",
+			expectedQueries: []string{
+				"first.some.metric.*",
+				"second.some.metric.*",
+			},
+			expectedErr: nil,
+			desc:        "brackets in the start of query",
+		},
+		{
+			givenQuery: "some.metric.*.{first,second}",
+			expectedQueries: []string{
+				"some.metric.*.first",
+				"some.metric.*.second",
+			},
+			expectedErr: nil,
+			desc:        "brackets in the end of query",
+		},
+		{
+			givenQuery: "some.{first,second}.metric.*",
+			expectedQueries: []string{
+				"some.first.metric.*",
+				"some.second.metric.*",
+			},
+			expectedErr: nil,
+			desc:        "brackets in the middle of query",
+		},
+		{
+			givenQuery: "some.{fi*rst,second,th*ird}.metric.*",
+			expectedQueries: []string{
+				"some.fi*rst.metric.*",
+				"some.second.metric.*",
+				"some.th*ird.metric.*",
+			},
+			expectedErr: nil,
+			desc:        "brackets in the middle of query and some have wildcard",
+		},
+		{
+			givenQuery: "some.help_{fi*rst,second,th*ird}_me.metric.*",
+			expectedQueries: []string{
+				"some.help_fi*rst_me.metric.*",
+				"some.help_second_me.metric.*",
+				"some.help_th*ird_me.metric.*",
+			},
+			expectedErr: nil,
+			desc:        "brackets in the middle of query, in the middle of node and some have wildcard",
+		},
+		{
+			givenQuery: "{first,second}.some.{a,b,c}.metric",
+			expectedQueries: []string{
+				"{first,second}.some.a.metric",
+				"{first,second}.some.b.metric",
+				"{first,second}.some.c.metric",
+			},
+			expectedErr: nil,
+			desc:        "more than one bracket and reverse preferred",
+		},
+		{
+			givenQuery: "some.{a,b,c}.metric.{first,second}",
+			expectedQueries: []string{
+				"some.a.metric.{first,second}",
+				"some.b.metric.{first,second}",
+				"some.c.metric.{first,second}",
+			},
+			expectedErr: nil,
+			desc:        "more than one bracket and direct preferred",
+		},
+		{
+			givenQuery: "some.{a,b}.{first,second}.metric",
+			expectedQueries: []string{
+				"some.a.{first,second}.metric",
+				"some.b.{first,second}.metric",
+			},
+			expectedErr: nil,
+			desc:        "more than one bracket on equal distance, direct preferred",
+		},
+	}
+
+	for _, singleCase := range cases {
+		t.Run(singleCase.desc, func(t *testing.T) {
+			gotQueries, gotErr := splitQuery(singleCase.givenQuery)
+
+			assert.Equal(t, singleCase.expectedQueries, gotQueries, singleCase.desc)
+			assert.Equal(t, singleCase.expectedErr, gotErr, singleCase.desc)
+		})
+	}
+}

--- a/finder/split_test.go
+++ b/finder/split_test.go
@@ -3,7 +3,11 @@ package finder
 import (
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/lomik/graphite-clickhouse/config"
+	"github.com/lomik/graphite-clickhouse/helper/clickhouse"
+	"github.com/lomik/graphite-clickhouse/helper/date"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -158,6 +162,150 @@ func Test_splitQuery(t *testing.T) {
 
 			assert.Equal(t, singleCase.expectedQueries, gotQueries, singleCase.desc)
 			assert.Equal(t, singleCase.expectedErr, gotErr, singleCase.desc)
+		})
+	}
+}
+
+func TestSplitIndexFinder_whereFilter(t *testing.T) {
+	type testcase struct {
+		name                string
+		givenQueries        []string
+		givenFrom           int64
+		givenUntil          int64
+		dailyEnabled        bool
+		wildcardMinDistance int
+		reverse             string
+		confReverses        config.IndexReverses
+		expectedWhereStr    string
+		expectedErr         error
+	}
+
+	someFrom := time.Now().Unix() - 120
+	someUntil := time.Now().Unix()
+
+	cases := []testcase{
+		{
+			name: "no wildcards in queries, no daily",
+			givenQueries: []string{
+				"first.metric",
+				"second.metric",
+			},
+			dailyEnabled:     false,
+			expectedWhereStr: "((Path IN ('first.metric','first.metric.','second.metric','second.metric.')) AND (Level=20002)) AND (Date='1970-02-12')",
+		},
+		{
+			name: "wildcard in queries, reverse preferred, no daily",
+			givenQueries: []string{
+				"*.first.metric",
+				"*.second.metric",
+			},
+			dailyEnabled:     false,
+			expectedWhereStr: "(((Path LIKE 'metric.first.%') OR (Path LIKE 'metric.second.%')) AND (Level=30003)) AND (Date='1970-02-12')",
+		},
+		{
+			name: "no wildcards in queries, daily enabled, but no from and until",
+			givenQueries: []string{
+				"first.metric",
+				"second.metric",
+			},
+			dailyEnabled:     true,
+			expectedWhereStr: "((Path IN ('first.metric','first.metric.','second.metric','second.metric.')) AND (Level=20002)) AND (Date='1970-02-12')",
+		},
+		{
+			name: "no wildcards in queries, daily enabled, has from, until",
+			givenQueries: []string{
+				"first.metric",
+				"second.metric",
+			},
+			givenFrom:    someFrom,
+			givenUntil:   someFrom,
+			dailyEnabled: true,
+			expectedWhereStr: "((Path IN ('first.metric','first.metric.','second.metric','second.metric.')) AND (Level=2)) AND (Date >='" +
+				date.FromTimestampToDaysFormat(someFrom) + "' AND Date <= '" + date.UntilTimestampToDaysFormat(someUntil) + "')",
+		},
+		{
+			name: "wildcard in queries, reverse preferred, daily enabled, no from, until",
+			givenQueries: []string{
+				"*.first.metric",
+				"*.second.metric",
+			},
+			dailyEnabled:     true,
+			expectedWhereStr: "(((Path LIKE 'metric.first.%') OR (Path LIKE 'metric.second.%')) AND (Level=30003)) AND (Date='1970-02-12')",
+		},
+		{
+			name: "wildcard in queries, reverse preferred, daily enabled, has from, until",
+			givenQueries: []string{
+				"*.first.metric",
+				"*.second.metric",
+			},
+			dailyEnabled: true,
+			givenFrom:    someFrom,
+			givenUntil:   someUntil,
+			expectedWhereStr: "(((Path LIKE 'metric.first.%') OR (Path LIKE 'metric.second.%')) AND (Level=10003)) AND (Date >='" +
+				date.FromTimestampToDaysFormat(someFrom) + "' AND Date <= '" + date.UntilTimestampToDaysFormat(someUntil) + "')",
+		},
+		{
+			name: "some queries have wildcard, daily enabled, has from, until",
+			givenQueries: []string{
+				"help.*first.metric",
+				"help.second.metric",
+				"help.th*rd.metric",
+				"help.forth.metric",
+			},
+			dailyEnabled: true,
+			givenFrom:    someFrom,
+			givenUntil:   someUntil,
+			expectedWhereStr: "((((Path LIKE 'help.%' AND match(Path, '^help[.]([^.]*?)first[.]metric[.]?$')) OR (Path LIKE 'help.th%' AND match(Path, '^help[.]th([^.]*?)rd[.]metric[.]?$'))) OR (Path IN ('help.second.metric','help.second.metric.','help.forth.metric','help.forth.metric.'))) AND (Level=3)) AND (Date >='" +
+				date.FromTimestampToDaysFormat(someFrom) + "' AND Date <= '" + date.UntilTimestampToDaysFormat(someUntil) + "')",
+		},
+		{
+			name: "some queries have wildcard, daily enabled, has from, until, but reverse preferred",
+			givenQueries: []string{
+				"help.*first.metric.count",
+				"help.second.metric.count",
+				"help.th*rd.metric.count",
+				"help.forth.metric.count",
+			},
+			dailyEnabled: true,
+			givenFrom:    someFrom,
+			givenUntil:   someUntil,
+			expectedWhereStr: "((((Path LIKE 'count.metric.%' AND match(Path, '^count[.]metric[.]([^.]*?)first[.]help[.]?$')) OR (Path LIKE 'count.metric.th%' AND match(Path, '^count[.]metric[.]th([^.]*?)rd[.]help[.]?$'))) OR (Path IN ('count.metric.second.help','count.metric.second.help.','count.metric.forth.help','count.metric.forth.help.'))) AND (Level=10004)) AND (Date >='" +
+				date.FromTimestampToDaysFormat(someFrom) + "' AND Date <= '" + date.UntilTimestampToDaysFormat(someUntil) + "')",
+			expectedErr: nil,
+		},
+		{
+			name: "some queries have wildcard, daily enabled, has from, until, but reverse preferred, first query has no wildcard",
+			givenQueries: []string{
+				"help.second.metric.count",
+				"help.*first.metric.count",
+				"help.th*rd.metric.count",
+				"help.forth.metric.count",
+			},
+			dailyEnabled: true,
+			givenFrom:    someFrom,
+			givenUntil:   someUntil,
+			expectedWhereStr: "((((Path LIKE 'count.metric.%' AND match(Path, '^count[.]metric[.]([^.]*?)first[.]help[.]?$')) OR (Path LIKE 'count.metric.th%' AND match(Path, '^count[.]metric[.]th([^.]*?)rd[.]help[.]?$'))) OR (Path IN ('count.metric.second.help','count.metric.second.help.','count.metric.forth.help','count.metric.forth.help.'))) AND (Level=10004)) AND (Date >='" +
+				date.FromTimestampToDaysFormat(someFrom) + "' AND Date <= '" + date.UntilTimestampToDaysFormat(someUntil) + "')",
+			expectedErr: nil,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("Case %v: %s", i+1, tc.name), func(t *testing.T) {
+			f := WrapSplitIndex(
+				&IndexFinder{},
+				tc.wildcardMinDistance,
+				"http://localhost:8123/",
+				"graphite_index",
+				tc.dailyEnabled,
+				tc.reverse,
+				tc.confReverses,
+				clickhouse.Options{},
+				false)
+
+			got, err := f.whereFilter(tc.givenQueries, tc.givenFrom, tc.givenUntil)
+			assert.Equal(t, tc.expectedErr, err)
+			assert.Equal(t, tc.expectedWhereStr, got.String())
 		})
 	}
 }

--- a/pkg/where/match.go
+++ b/pkg/where/match.go
@@ -9,8 +9,8 @@ var (
 	opEq string = "="
 )
 
-// clearGlob cleanup grafana globs like {name}
-func clearGlob(query string) string {
+// ClearGlob cleanup grafana globs like {name}
+func ClearGlob(query string) string {
 	p := 0
 	s := strings.IndexAny(query, "{[")
 	if s == -1 {
@@ -121,7 +121,7 @@ func glob(field string, query string, optionalDotAtEnd bool) string {
 		return ""
 	}
 
-	query = clearGlob(query)
+	query = ClearGlob(query)
 
 	if !HasWildcard(query) {
 		if optionalDotAtEnd {

--- a/pkg/where/match_test.go
+++ b/pkg/where/match_test.go
@@ -2,7 +2,7 @@ package where
 
 import "testing"
 
-func Test_clearGlob(t *testing.T) {
+func Test_ClearGlob(t *testing.T) {
 	type args struct {
 		query string
 	}
@@ -21,8 +21,8 @@ func Test_clearGlob(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.query, func(t *testing.T) {
-			if got := clearGlob(tt.query); got != tt.want {
-				t.Errorf("clearGlob() = %v, want %v", got, tt.want)
+			if got := ClearGlob(tt.query); got != tt.want {
+				t.Errorf("ClearGlob() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
# PR summary

Add options to config: 
- `try-split-query` (default: `false`). On `true` graphite-clickhouse will split a query with `{}` in it into multiple queries.
- `max-node-to-split-index` (default: `0`). Works only if `try-split-query = true`. Will not split query if both lists are at index greater than this param.

For example: `{a,b,c}.some.metric` will be split into `a.some.metric`, `b.some.metric`, `c.some.metric`. Only one `{}` will be split.
There some cases then query will not be split:
- beacuse of not satisfing `max-node-to-split-index` condition;
- because query has wildcard before `{}`;

After that conditions for multiple graphite queries are aggregated into single SQL query.
