### PR TITLE
feature: Use `has` instead of `arrayExists` where possible

### DIFF
--- a/autocomplete/autocomplete.go
+++ b/autocomplete/autocomplete.go
@@ -529,8 +529,9 @@ func (h *Handler) ServeValues(w http.ResponseWriter, r *http.Request) {
 			valueSQL = fmt.Sprintf("substr(Tag1, %d) AS value", len(tag)+2)
 			wr.And(where.HasPrefix("Tag1", tag+"="+valuePrefix))
 		} else {
-			valueSQL = fmt.Sprintf("substr(arrayJoin(Tags), %d) AS value", len(tag)+2)
-			wr.And(where.HasPrefix("arrayJoin(Tags)", tag+"="+valuePrefix))
+			prefixSelector := where.HasPrefix("x", tag+"="+valuePrefix)
+			valueSQL = fmt.Sprintf("substr(arrayFilter(x -> %s, Tags)[1], %d) AS value", prefixSelector, len(tag)+2)
+			wr.And("arrayExists(x -> " + prefixSelector + ", Tags)")
 		}
 
 		wr.Andf("Date >= '%s' AND Date <= '%s'", fromDate, untilDate)

--- a/autocomplete/autocomplete_test.go
+++ b/autocomplete/autocomplete_test.go
@@ -67,7 +67,7 @@ func TestHandler_ServeValues(t *testing.T) {
 	from := strconv.FormatInt(now.Add(-time.Minute).Unix(), 10)
 	fromDate, untilDate := dateString(h.config.ClickHouse.TaggedAutocompleDays, now)
 
-	srv.AddResponce(//"SELECT substr(arrayJoin(Tags), 6) AS value FROM graphite_tagged  WHERE (((Tag1='environment=production') AND (has(Tags, 'project=web'))) AND (arrayJoin(Tags) LIKE 'host=%')) AND (Date >= '2022-11-22' AND Date <= '2022-11-29') GROUP BY value ORDER BY value LIMIT 10000"
+	srv.AddResponce(
 		"SELECT substr(arrayJoin(Tags), 6) AS value FROM graphite_tagged  WHERE (((Tag1='environment=production') AND (has(Tags, 'project=web'))) AND (arrayJoin(Tags) LIKE 'host=%')) AND "+
 			"(Date >= '"+fromDate+"' AND Date <= '"+untilDate+"') GROUP BY value ORDER BY value LIMIT 10000",
 		&chtest.TestResponse{

--- a/autocomplete/autocomplete_test.go
+++ b/autocomplete/autocomplete_test.go
@@ -67,8 +67,8 @@ func TestHandler_ServeValues(t *testing.T) {
 	from := strconv.FormatInt(now.Add(-time.Minute).Unix(), 10)
 	fromDate, untilDate := dateString(h.config.ClickHouse.TaggedAutocompleDays, now)
 
-	srv.AddResponce(
-		"SELECT substr(arrayJoin(Tags), 6) AS value FROM graphite_tagged  WHERE (((Tag1='environment=production') AND (arrayExists((x) -> x='project=web', Tags))) AND (arrayJoin(Tags) LIKE 'host=%')) AND "+
+	srv.AddResponce(//"SELECT substr(arrayJoin(Tags), 6) AS value FROM graphite_tagged  WHERE (((Tag1='environment=production') AND (has(Tags, 'project=web'))) AND (arrayJoin(Tags) LIKE 'host=%')) AND (Date >= '2022-11-22' AND Date <= '2022-11-29') GROUP BY value ORDER BY value LIMIT 10000"
+		"SELECT substr(arrayJoin(Tags), 6) AS value FROM graphite_tagged  WHERE (((Tag1='environment=production') AND (has(Tags, 'project=web'))) AND (arrayJoin(Tags) LIKE 'host=%')) AND "+
 			"(Date >= '"+fromDate+"' AND Date <= '"+untilDate+"') GROUP BY value ORDER BY value LIMIT 10000",
 		&chtest.TestResponse{
 			Body: []byte("host1\nhost2\ndc-host2\ndc-host3\n"),
@@ -129,7 +129,7 @@ func TestTagsAutocomplete_ServeValuesCached(t *testing.T) {
 	fromDate, untilDate := dateString(h.config.ClickHouse.TaggedAutocompleDays, now)
 
 	srv.AddResponce(
-		"SELECT substr(arrayJoin(Tags), 6) AS value FROM graphite_tagged  WHERE (((Tag1='environment=production') AND (arrayExists((x) -> x='project=web', Tags))) AND (arrayJoin(Tags) LIKE 'host=%')) AND "+
+		"SELECT substr(arrayJoin(Tags), 6) AS value FROM graphite_tagged  WHERE (((Tag1='environment=production') AND (has(Tags, 'project=web'))) AND (arrayJoin(Tags) LIKE 'host=%')) AND "+
 			"(Date >= '"+fromDate+"' AND Date <= '"+untilDate+"') GROUP BY value ORDER BY value LIMIT 10000",
 		&chtest.TestResponse{
 			Body: []byte("host1\nhost2\ndc-host2\ndc-host3\n"),

--- a/autocomplete/autocomplete_test.go
+++ b/autocomplete/autocomplete_test.go
@@ -68,7 +68,7 @@ func TestHandler_ServeValues(t *testing.T) {
 	fromDate, untilDate := dateString(h.config.ClickHouse.TaggedAutocompleDays, now)
 
 	srv.AddResponce(
-		"SELECT substr(arrayJoin(Tags), 6) AS value FROM graphite_tagged  WHERE (((Tag1='environment=production') AND (has(Tags, 'project=web'))) AND (arrayJoin(Tags) LIKE 'host=%')) AND "+
+		"SELECT substr(arrayFilter(x -> x LIKE 'host=%', Tags)[1], 6) AS value FROM graphite_tagged  WHERE (((Tag1='environment=production') AND (has(Tags, 'project=web'))) AND (arrayExists(x -> x LIKE 'host=%', Tags))) AND "+
 			"(Date >= '"+fromDate+"' AND Date <= '"+untilDate+"') GROUP BY value ORDER BY value LIMIT 10000",
 		&chtest.TestResponse{
 			Body: []byte("host1\nhost2\ndc-host2\ndc-host3\n"),
@@ -129,7 +129,7 @@ func TestTagsAutocomplete_ServeValuesCached(t *testing.T) {
 	fromDate, untilDate := dateString(h.config.ClickHouse.TaggedAutocompleDays, now)
 
 	srv.AddResponce(
-		"SELECT substr(arrayJoin(Tags), 6) AS value FROM graphite_tagged  WHERE (((Tag1='environment=production') AND (has(Tags, 'project=web'))) AND (arrayJoin(Tags) LIKE 'host=%')) AND "+
+		"SELECT substr(arrayFilter(x -> x LIKE 'host=%', Tags)[1], 6) AS value FROM graphite_tagged  WHERE (((Tag1='environment=production') AND (has(Tags, 'project=web'))) AND (arrayExists(x -> x LIKE 'host=%', Tags))) AND "+
 			"(Date >= '"+fromDate+"' AND Date <= '"+untilDate+"') GROUP BY value ORDER BY value LIMIT 10000",
 		&chtest.TestResponse{
 			Body: []byte("host1\nhost2\ndc-host2\ndc-host3\n"),

--- a/finder/tagged.go
+++ b/finder/tagged.go
@@ -188,11 +188,15 @@ func TaggedTermWhereN(term *TaggedTerm, useCarbonBehaviour, dontMatchMissingTags
 			return "", err
 		}
 		if len(values) == 1 {
-			return "arrayExists((x) -> " + where.Eq("x", values[0]) + ", Tags)", nil
+			return where.ArrayHas("Tags", values[0]), nil
 		} else if len(values) > 1 {
-			return "arrayExists((x) -> " + where.In("x", values) + ", Tags)", nil
+			w := where.New()
+			for _, v := range values {
+				w.And(where.ArrayHas("Tags", v))
+			}
+			return w.String(), nil
 		} else {
-			return "arrayExists((x) -> " + where.Eq("x", term.concat()) + ", Tags)", nil
+			return where.ArrayHas("Tags", term.concat()), nil
 		}
 	case TaggedTermNe:
 		if term.Value == "" {

--- a/finder/tagged.go
+++ b/finder/tagged.go
@@ -192,7 +192,7 @@ func TaggedTermWhereN(term *TaggedTerm, useCarbonBehaviour, dontMatchMissingTags
 		} else if len(values) > 1 {
 			w := where.New()
 			for _, v := range values {
-				w.And(where.ArrayHas("Tags", v))
+				w.Or(where.ArrayHas("Tags", v))
 			}
 			return w.String(), nil
 		} else {

--- a/finder/tagged_test.go
+++ b/finder/tagged_test.go
@@ -65,7 +65,7 @@ func TestTaggedWhere(t *testing.T) {
 		{"seriesByTag('name=m{in}')", 0, "Tag1='__name__=min'", "", false},
 		{"seriesByTag('name=m{in,ax}')", 0, "Tag1 IN ('__name__=min','__name__=max')", "", false},
 		{"seriesByTag('name=m{in,ax')", 0, "", "", true},
-		{"seriesByTag('name=value','what={avg,max}')", 0, "(Tag1='__name__=value') AND (arrayExists((x) -> x IN ('what=avg','what=max'), Tags))", "", false},
+		{"seriesByTag('name=value','what={avg,max}')", 0, "(Tag1='__name__=value') AND ((has(Tags, 'what=avg')) AND (has(Tags, 'what=max')))", "", false},
 		{"seriesByTag('name=value','what!={avg,max}')", 0, "(Tag1='__name__=value') AND (NOT arrayExists((x) -> x IN ('what=avg','what=max'), Tags))", "", false},
 		// grafana workaround for multi-value variables default, masked with *
 		{"seriesByTag('name=value','what=~*')", 0, "(Tag1='__name__=value') AND (arrayExists((x) -> x LIKE 'what=%', Tags))", "", false}, // If All masked to value with *
@@ -73,7 +73,7 @@ func TestTaggedWhere(t *testing.T) {
 		{"seriesByTag('name=value','what=~')", 0, "(Tag1='__name__=value') AND (arrayExists((x) -> x LIKE 'what=%', Tags))", "", false}, // If All masked to value with *
 		// testcases for useCarbonBehaviour=false
 		{"seriesByTag('what=')", 0, "Tag1='what='", "", false},
-		{"seriesByTag('name=value','what=')", 0, "(Tag1='__name__=value') AND (arrayExists((x) -> x='what=', Tags))", "", false},
+		{"seriesByTag('name=value','what=')", 0, "(Tag1='__name__=value') AND (has(Tags, 'what='))", "", false},
 		// testcases for dontMatchMissingTags=false
 		{"seriesByTag('key!=value')", 0, "NOT arrayExists((x) -> x='key=value', Tags)", "", false},
 		{"seriesByTag('dc!=de', 'cpu=cpu-total')", 0, "(Tag1='cpu=cpu-total') AND (NOT arrayExists((x) -> x='dc=de', Tags))", "", false},
@@ -164,7 +164,7 @@ func TestTaggedWhere_UseCarbonBehaviourFlag(t *testing.T) {
 		{"seriesByTag('name=m{in}')", 0, "Tag1='__name__=min'", "", false},
 		{"seriesByTag('name=m{in,ax}')", 0, "Tag1 IN ('__name__=min','__name__=max')", "", false},
 		{"seriesByTag('name=m{in,ax')", 0, "", "", true},
-		{"seriesByTag('name=value','what={avg,max}')", 0, "(Tag1='__name__=value') AND (arrayExists((x) -> x IN ('what=avg','what=max'), Tags))", "", false},
+		{"seriesByTag('name=value','what={avg,max}')", 0, "(Tag1='__name__=value') AND ((has(Tags, 'what=avg')) AND (has(Tags, 'what=max')))", "", false},
 		{"seriesByTag('name=value','what!={avg,max}')", 0, "(Tag1='__name__=value') AND (NOT arrayExists((x) -> x IN ('what=avg','what=max'), Tags))", "", false},
 		// grafana workaround for multi-value variables default, masked with *
 		{"seriesByTag('name=value','what=~*')", 0, "(Tag1='__name__=value') AND (arrayExists((x) -> x LIKE 'what=%', Tags))", "", false}, // If All masked to value with *
@@ -264,7 +264,7 @@ func TestTaggedWhere_DontMatchMissingTagsFlag(t *testing.T) {
 		{"seriesByTag('name=m{in}')", 0, "Tag1='__name__=min'", "", false},
 		{"seriesByTag('name=m{in,ax}')", 0, "Tag1 IN ('__name__=min','__name__=max')", "", false},
 		{"seriesByTag('name=m{in,ax')", 0, "", "", true},
-		{"seriesByTag('name=value','what={avg,max}')", 0, "(Tag1='__name__=value') AND (arrayExists((x) -> x IN ('what=avg','what=max'), Tags))", "", false},
+		{"seriesByTag('name=value','what={avg,max}')", 0, "(Tag1='__name__=value') AND ((has(Tags, 'what=avg')) AND (has(Tags, 'what=max')))", "", false},
 		// {"seriesByTag('name=value','what!={avg,max}')", 0, "(Tag1='__name__=value') AND (NOT arrayExists((x) -> x IN ('what=avg','what=max'), Tags))", "", false},
 		{"seriesByTag('name=value','what!={avg,max}')", 0, "(Tag1='__name__=value') AND (arrayExists((x) -> x LIKE 'what=%', Tags) AND NOT arrayExists((x) -> x IN ('what=avg','what=max'), Tags))", "", false},
 		// grafana workaround for multi-value variables default, masked with *
@@ -273,7 +273,7 @@ func TestTaggedWhere_DontMatchMissingTagsFlag(t *testing.T) {
 		{"seriesByTag('name=value','what=~')", 0, "(Tag1='__name__=value') AND (arrayExists((x) -> x LIKE 'what=%', Tags))", "", false}, // If All masked to value with *
 		// testcases for useCarbonBehaviour=false
 		{"seriesByTag('what=')", 0, "Tag1='what='", "", false},
-		{"seriesByTag('name=value','what=')", 0, "(Tag1='__name__=value') AND (arrayExists((x) -> x='what=', Tags))", "", false},
+		{"seriesByTag('name=value','what=')", 0, "(Tag1='__name__=value') AND (has(Tags, 'what='))", "", false},
 		// testcases for dontMatchMissingTags=true
 		{"seriesByTag('key!=value')", 0, "Tag1 LIKE 'key=%' AND NOT arrayExists((x) -> x='key=value', Tags)", "", false},
 		{"seriesByTag('dc!=de', 'cpu=cpu-total')", 0, "(Tag1='cpu=cpu-total') AND (arrayExists((x) -> x LIKE 'dc=%', Tags) AND NOT arrayExists((x) -> x='dc=de', Tags))", "", false},
@@ -365,7 +365,7 @@ func TestTaggedWhere_BothFeatureFlags(t *testing.T) {
 		{"seriesByTag('name=m{in}')", 0, "Tag1='__name__=min'", "", false},
 		{"seriesByTag('name=m{in,ax}')", 0, "Tag1 IN ('__name__=min','__name__=max')", "", false},
 		{"seriesByTag('name=m{in,ax')", 0, "", "", true},
-		{"seriesByTag('name=value','what={avg,max}')", 0, "(Tag1='__name__=value') AND (arrayExists((x) -> x IN ('what=avg','what=max'), Tags))", "", false},
+		{"seriesByTag('name=value','what={avg,max}')", 0, "(Tag1='__name__=value') AND ((has(Tags, 'what=avg')) AND (has(Tags, 'what=max')))", "", false},
 		// {"seriesByTag('name=value','what!={avg,max}')", 0, "(Tag1='__name__=value') AND (NOT arrayExists((x) -> x IN ('what=avg','what=max'), Tags))", "", false},
 		{"seriesByTag('name=value','what!={avg,max}')", 0, "(Tag1='__name__=value') AND (arrayExists((x) -> x LIKE 'what=%', Tags) AND NOT arrayExists((x) -> x IN ('what=avg','what=max'), Tags))", "", false},
 		// grafana workaround for multi-value variables default, masked with *

--- a/finder/tagged_test.go
+++ b/finder/tagged_test.go
@@ -65,7 +65,7 @@ func TestTaggedWhere(t *testing.T) {
 		{"seriesByTag('name=m{in}')", 0, "Tag1='__name__=min'", "", false},
 		{"seriesByTag('name=m{in,ax}')", 0, "Tag1 IN ('__name__=min','__name__=max')", "", false},
 		{"seriesByTag('name=m{in,ax')", 0, "", "", true},
-		{"seriesByTag('name=value','what={avg,max}')", 0, "(Tag1='__name__=value') AND ((has(Tags, 'what=avg')) AND (has(Tags, 'what=max')))", "", false},
+		{"seriesByTag('name=value','what={avg,max}')", 0, "(Tag1='__name__=value') AND ((has(Tags, 'what=avg')) OR (has(Tags, 'what=max')))", "", false},
 		{"seriesByTag('name=value','what!={avg,max}')", 0, "(Tag1='__name__=value') AND (NOT arrayExists((x) -> x IN ('what=avg','what=max'), Tags))", "", false},
 		// grafana workaround for multi-value variables default, masked with *
 		{"seriesByTag('name=value','what=~*')", 0, "(Tag1='__name__=value') AND (arrayExists((x) -> x LIKE 'what=%', Tags))", "", false}, // If All masked to value with *
@@ -164,7 +164,7 @@ func TestTaggedWhere_UseCarbonBehaviourFlag(t *testing.T) {
 		{"seriesByTag('name=m{in}')", 0, "Tag1='__name__=min'", "", false},
 		{"seriesByTag('name=m{in,ax}')", 0, "Tag1 IN ('__name__=min','__name__=max')", "", false},
 		{"seriesByTag('name=m{in,ax')", 0, "", "", true},
-		{"seriesByTag('name=value','what={avg,max}')", 0, "(Tag1='__name__=value') AND ((has(Tags, 'what=avg')) AND (has(Tags, 'what=max')))", "", false},
+		{"seriesByTag('name=value','what={avg,max}')", 0, "(Tag1='__name__=value') AND ((has(Tags, 'what=avg')) OR (has(Tags, 'what=max')))", "", false},
 		{"seriesByTag('name=value','what!={avg,max}')", 0, "(Tag1='__name__=value') AND (NOT arrayExists((x) -> x IN ('what=avg','what=max'), Tags))", "", false},
 		// grafana workaround for multi-value variables default, masked with *
 		{"seriesByTag('name=value','what=~*')", 0, "(Tag1='__name__=value') AND (arrayExists((x) -> x LIKE 'what=%', Tags))", "", false}, // If All masked to value with *
@@ -264,7 +264,7 @@ func TestTaggedWhere_DontMatchMissingTagsFlag(t *testing.T) {
 		{"seriesByTag('name=m{in}')", 0, "Tag1='__name__=min'", "", false},
 		{"seriesByTag('name=m{in,ax}')", 0, "Tag1 IN ('__name__=min','__name__=max')", "", false},
 		{"seriesByTag('name=m{in,ax')", 0, "", "", true},
-		{"seriesByTag('name=value','what={avg,max}')", 0, "(Tag1='__name__=value') AND ((has(Tags, 'what=avg')) AND (has(Tags, 'what=max')))", "", false},
+		{"seriesByTag('name=value','what={avg,max}')", 0, "(Tag1='__name__=value') AND ((has(Tags, 'what=avg')) OR (has(Tags, 'what=max')))", "", false},
 		// {"seriesByTag('name=value','what!={avg,max}')", 0, "(Tag1='__name__=value') AND (NOT arrayExists((x) -> x IN ('what=avg','what=max'), Tags))", "", false},
 		{"seriesByTag('name=value','what!={avg,max}')", 0, "(Tag1='__name__=value') AND (arrayExists((x) -> x LIKE 'what=%', Tags) AND NOT arrayExists((x) -> x IN ('what=avg','what=max'), Tags))", "", false},
 		// grafana workaround for multi-value variables default, masked with *
@@ -365,7 +365,7 @@ func TestTaggedWhere_BothFeatureFlags(t *testing.T) {
 		{"seriesByTag('name=m{in}')", 0, "Tag1='__name__=min'", "", false},
 		{"seriesByTag('name=m{in,ax}')", 0, "Tag1 IN ('__name__=min','__name__=max')", "", false},
 		{"seriesByTag('name=m{in,ax')", 0, "", "", true},
-		{"seriesByTag('name=value','what={avg,max}')", 0, "(Tag1='__name__=value') AND ((has(Tags, 'what=avg')) AND (has(Tags, 'what=max')))", "", false},
+		{"seriesByTag('name=value','what={avg,max}')", 0, "(Tag1='__name__=value') AND ((has(Tags, 'what=avg')) OR (has(Tags, 'what=max')))", "", false},
 		// {"seriesByTag('name=value','what!={avg,max}')", 0, "(Tag1='__name__=value') AND (NOT arrayExists((x) -> x IN ('what=avg','what=max'), Tags))", "", false},
 		{"seriesByTag('name=value','what!={avg,max}')", 0, "(Tag1='__name__=value') AND (arrayExists((x) -> x LIKE 'what=%', Tags) AND NOT arrayExists((x) -> x IN ('what=avg','what=max'), Tags))", "", false},
 		// grafana workaround for multi-value variables default, masked with *

--- a/pkg/where/where.go
+++ b/pkg/where/where.go
@@ -171,6 +171,10 @@ func HasPrefixBytes(field, prefix []byte) string {
 	return fmt.Sprintf("%s LIKE '%s%%'", field, likeEscape(unsafeString(prefix)))
 }
 
+func ArrayHas(field, element string) string {
+	return fmt.Sprintf("has(%s, %s)", field, quote(element))
+}
+
 func In(field string, list []string) string {
 	if len(list) == 1 {
 		return Eq(field, list[0])


### PR DESCRIPTION
## Indices

Clickhouse of version `22.12.3` can not apply `tokenbf_v1` skip indices to queries with `arrayExists(x -> x = '...', Tags)`, but can for queries with `has(Tags, '...')`

This PR replaces arrayExists with has in `TaggedTermWhereN` function, to allow usage of tokenbf_v1 index

Example of index that can be used:

```sql
ALTER TABLE <carbon_clickhouse_table_tags> 
ADD INDEX IF NOT EXISTS tags_array_bloom_skip_idx Tags
TYPE tokenbf_v1(16384, 3, 0) GRANULARITY 1;
```

Such index give a good selectivity boost to most tag queries.

## Other

Optimized selection of variables in autocomplete via replacing `arrayJoin` requests with `arrayExists` and `arrayFilter`. On our data this gives an approximately x10 perfomance boost on tag selection.